### PR TITLE
Füge fehlende Überschriften in Kapitel 2 hinzu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ clean:
 	rm -f vorkurs.toc
 	rm -f basics/*.aux
 	rm -f basics/*.log
+	rm -f classes/*.aux
+	rm -f classes/*.log
 	rm -rf _minted-vorkurs
 
 # Die Dateien in "files" werden ins Skript eingebunden und müssen den Erstis

--- a/classes/intro.tex
+++ b/classes/intro.tex
@@ -1,4 +1,4 @@
-\chapter{Einführung in Objektorientierung \& Klassen}
+\chapter[Objektorientierung]{Einführung in Objektorientierung \& Klassen}
 \pagestyle{empty}
 
 Im zweiten Kapitel werden wir lernen einfache Datentypen zu komplexeren Typen in Klassen zusammenzufassen.

--- a/classes/intro.tex
+++ b/classes/intro.tex
@@ -3,6 +3,7 @@
 
 Im zweiten Kapitel werden wir lernen einfache Datentypen zu komplexeren Typen in Klassen zusammenzufassen.
 
+\pagestyle{fancy}
 \include{classes/enum}
 \include{classes/struct}
 \include{classes/operator}

--- a/classes/struct.tex
+++ b/classes/struct.tex
@@ -1,4 +1,4 @@
-\lesson{Struct und Konstruktor} % Anderer Name?
+\lesson{Structs}
 
 Wir sind bisher dazu in der Lage Variablen von vielen, verschiedenen Typen anzulegen.
 Wir wollen uns jetzt damit beschäftigen wie wir dreidimensionale Vektoren in \Cpp implementieren können.

--- a/vorkurs.cls
+++ b/vorkurs.cls
@@ -3,7 +3,7 @@
 
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{scrbook}}
 \ProcessOptions\relax
-\LoadClass[a4paper,oneside]{scrbook}
+\LoadClass[a4paper,oneside,headings=optiontohead]{scrbook}
 
 \RequirePackage{fancyhdr}
 \RequirePackage[explicit,clearempty]{titlesec}

--- a/vorkurs.cls
+++ b/vorkurs.cls
@@ -15,7 +15,7 @@
 \RequirePackage{minted}
 
 %\setcounter{secnumdepth}{-1}
-
+\pagestyle{fancy}
 \setlength{\parskip}{0.5em}
 \setlength{\parindent}{0pt}
 \addtolength{\headheight}{\baselineskip}


### PR DESCRIPTION
Ist Issue #89 

Problem war, dass die Überschriften teil des pagestyles sind, der wurde für die ersten paar Worte vom Kapitel ausgeschaltet, aber nicht wieder angeschaltet.

Ich hab außerdem noch die temporary files von Latex aus dem zweiten Kapitel in das cleanup vom Makefile hinzugefügt.