### PR TITLE
Komische Umbrüche vermeiden

### DIFF
--- a/basics/arith.tex
+++ b/basics/arith.tex
@@ -28,51 +28,51 @@ diesem:
 
 \inputcpp{arith2.cpp}
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Was gibt dieses Programm aus? Überlegt es euch zuerst und kompiliert
-        es dann, um es auszuprobieren.
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Was gibt dieses Programm aus? Überlegt es euch zuerst und kompiliert
+              es dann, um es auszuprobieren.
+    \end{enumerate}
 
-Obwohl \texttt{a = a + 19} mathematisch überhaupt keinen Sinn ergibt, ist doch
-klar, was passiert, wenn man sich den Quellcode eben nicht als Reihe von
-Aussagen, sondern als Folge von \emph{Anweisungen} vorstellt. Das
-Gleichheitszeichen bedeutet dann nicht, dass beide Seiten gleich sein sollen,
-sondern dass der Wert auf der linken Seite den Wert auf der rechten Seite
-annehmen soll.
+    Obwohl \texttt{a = a + 19} mathematisch überhaupt keinen Sinn ergibt, ist doch
+    klar, was passiert, wenn man sich den Quellcode eben nicht als Reihe von
+    Aussagen, sondern als Folge von \emph{Anweisungen} vorstellt. Das
+    Gleichheitszeichen bedeutet dann nicht, dass beide Seiten gleich sein sollen,
+    sondern dass der Wert auf der linken Seite den Wert auf der rechten Seite
+    annehmen soll.
 
-Wie wir in diesem Beispiel ausserdem sehen, können wir nicht nur Strings
-ausgeben, sondern auch Zahlen. \texttt{std::cout} gibt sie in einer Form aus,
-in der wir etwas damit anfangen können. Genauso können wir auch über
-\texttt{std::cin} Zahlen vom Benutzer entgegen nehmen:
+    Wie wir in diesem Beispiel ausserdem sehen, können wir nicht nur Strings
+    ausgeben, sondern auch Zahlen. \texttt{std::cout} gibt sie in einer Form aus,
+    in der wir etwas damit anfangen können. Genauso können wir auch über
+    \texttt{std::cin} Zahlen vom Benutzer entgegen nehmen:
 
-\inputcpp{arith3.cpp}
+    \inputcpp{arith3.cpp}
 
-Langsam aber sicher tasten wir uns an nützliche Programme heran!
+    Langsam aber sicher tasten wir uns an nützliche Programme heran!
 
-\textbf{Praxis:}
-\begin{enumerate}[resume]
-    \item Schreibt ein Programm, welches von der Nutzerin zwei ganze Zahlen
-        entgegen nimmt und anschließend Summe, Differenz, Produkt und Quotient
-        ausspuckt.
-    \item Was fällt auf, wenn ihr z.B. 19 und 7 eingebt?
-	\item Findet heraus (Google ist euer Freund), wie man in \Cpp Division mit
-		Rest durchführt und gebt diese zusätzlich zu den bisherigen Operationen
-		mit aus\footnote{Falls ihr nicht weiterkommt, hilft euch vielleicht das
-		Stichwort „modulo“ oder „modulo-operator“ weiter.}.
-    \item Was passiert, wenn ihr als zweite Zahl eine 0 eingebt?
-\end{enumerate}
+    \begin{enumerate}[resume]
+        \item Schreibt ein Programm, welches von der Nutzerin zwei ganze Zahlen
+              entgegen nimmt und anschließend Summe, Differenz, Produkt und Quotient
+              ausspuckt.
+        \item Was fällt auf, wenn ihr z.B. 19 und 7 eingebt?
+        \item Findet heraus (Google ist euer Freund), wie man in \Cpp Division mit
+              Rest durchführt und gebt diese zusätzlich zu den bisherigen Operationen
+              mit aus\footnote{Falls ihr nicht weiterkommt, hilft euch vielleicht das
+                  Stichwort „modulo“ oder „modulo-operator“ weiter.}.
+        \item Was passiert, wenn ihr als zweite Zahl eine 0 eingebt?
+    \end{enumerate}
+\end{praxis}
 
-\textbf{Spiel:}
-\begin{enumerate}
-    \item Findet heraus, was die größte positive (und was die kleinste
-        negative) Zahl ist, die ihr in einem \texttt{int} speichern könnt.
-        Faulpelze nutzen Google, Lernbegierige versuchen sie experimentell zu
-        ermitteln. Was passiert, wenn ihr eine größere Zahl eingebt?
-    \item Wir arbeiten bisher nur mit \texttt{int}s für ganze Zahlen. Wenn wir
-        mit gebrochenen Zahlen rechnen wollen brauchen wir den Datentyp
-        \texttt{double}. Schreibt euer Mini Rechenprogramm so um, dass es statt
-        \texttt{int}s nur noch \texttt{double} benutzt und probiert es aus.
-        Achtet darauf, dass es Dezimalpunkte und Dezimalkommata gibt, wenn ihr
-        überraschende Ergebnisse erhaltet.
-\end{enumerate}
+\begin{spiel}
+    \begin{enumerate}
+        \item Findet heraus, was die größte positive (und was die kleinste
+              negative) Zahl ist, die ihr in einem \texttt{int} speichern könnt.
+              Faulpelze nutzen Google, Lernbegierige versuchen sie experimentell zu
+              ermitteln. Was passiert, wenn ihr eine größere Zahl eingebt?
+        \item Wir arbeiten bisher nur mit \texttt{int}s für ganze Zahlen. Wenn  wir mit gebrochenen Zahlen rechnen wollen brauchen wir den Datentyp
+              \texttt{double}. Schreibt euer Mini Rechenprogramm so um, dass es statt
+              \texttt{int}s nur noch \texttt{double} benutzt und probiert es aus.
+              Achtet darauf, dass es Dezimalpunkte und Dezimalkommata gibt, wenn ihr
+              überraschende Ergebnisse erhaltet.
+    \end{enumerate}
+\end{spiel}

--- a/basics/fehler.tex
+++ b/basics/fehler.tex
@@ -23,9 +23,9 @@ Nehmen wir z.B. mal folgendes Programm:
 Wenn wir versuchen, dieses zu kompilieren, gibt uns \texttt{g++} folgendes aus:
 
 \begin{textcode*}{label=g++ -o fehler1 fehler1.cpp}
-fehler1.cpp: In function 'int main()':
-fehler1.cpp:2:5: error: 'cout' is not a member of 'std'
-fehler1.cpp:2:35: error: 'endl' is not a member of 'std'
+    fehler1.cpp: In function 'int main()':
+    fehler1.cpp:2:5: error: 'cout' is not a member of 'std'
+    fehler1.cpp:2:35: error: 'endl' is not a member of 'std'
 \end{textcode*}
 
 Wenn wir diese Fehlermeldung verstehen wollen, fangen wir immer ganz oben an,
@@ -56,8 +56,8 @@ Wenn wir versuchen, dies zu kompilieren, bekommen wir vom Compiler
 entgegengespuckt:
 
 \begin{textcode*}{label=g++ -o fehler2 fehler2.cpp}
-fehler2.cpp: In function 'int main()':
-fehler2.cpp:5:1: error: expected ';' before '}' token
+    fehler2.cpp: In function 'int main()':
+    fehler2.cpp:5:1: error: expected ';' before '}' token
 \end{textcode*}
 
 Wiederum sagt uns die erste Zeile, in welcher Datei und Funktion der Fehler
@@ -78,28 +78,31 @@ der richtigen Zeilennummer nachschlagt, aber nicht wisst, wo dort der Fehler
 sein sollte, schaut vielleicht mal ein oder zwei Zeilen darüber, vielleicht
 wusste der Compiler es einfach nicht besser.
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Versucht, folgende Dateien zu kompilieren und schaut euch die
-        Fehlermeldung an. In welcher Zeile, in welcher Spalte liegt der Fehler?
-        Was gibt euch der Compiler als Fehlermeldung aus?
-    \item Versucht, die aufgetretenen Fehler zu korrigieren. Bekommt ihr es
-        hin, dass der Compiler sich nicht mehr beschwert und das Programm
-        korrekt arbeitet (schaut euch ggf. die bisher gezeigten Quellcodes an)?
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Versucht, folgende Dateien zu kompilieren und schaut euch die
+              Fehlermeldung an. In welcher Zeile, in welcher Spalte liegt der Fehler?
+              Was gibt euch der Compiler als Fehlermeldung aus?
+        \item Versucht, die aufgetretenen Fehler zu korrigieren. Bekommt ihr es
+              hin, dass der Compiler sich nicht mehr beschwert und das Programm
+              korrekt arbeitet (schaut euch ggf. die bisher gezeigten Quellcodes an)?
+    \end{enumerate}
 
-\inputcpp{fehler3.cpp}
-\inputcpp{fehler4.cpp}
+    \inputcpp{fehler3.cpp}
 
-\textbf{Spiel:}
-\begin{enumerate}
-    \item Das folgende Programm enthält mehrere Fehler. Bekommt ihr trotzdem
-        raus, welche das sind und könnt ihr sie beheben (Tipp: „c++ math“ zu
-        \href{http://lmgtfy.com/?q=c\%2B\%2B+math}{googlen} kann euch hier vielleicht weiter bringen)?
-    \item Wenn ihr in den Vergangen Lektionen ein bisschen gespielt habt und
-        vereinzelnd versucht habt, Dinge zu löschen, Werden euch viele
-        Fehlermeldungen begegnet sein, versucht, diese zu lesen und
-        interpretieren, was euch der compiler hier sagen will.
-\end{enumerate}
+    \inputcpp{fehler4.cpp}
+\end{praxis}
 
-\inputcpp{fehler5.cpp}
+\begin{spiel}
+    \begin{enumerate}
+        \item Das folgende Programm enthält mehrere Fehler. Bekommt ihr trotzdem
+              raus, welche das sind und könnt ihr sie beheben (Tipp: „c++ math“ zu
+              \href{http://lmgtfy.com/?q=c\%2B\%2B+math}{googlen} kann euch hier vielleicht weiter bringen)?
+        \item Wenn ihr in den Vergangen Lektionen ein bisschen gespielt habt und
+              vereinzelnd versucht habt, Dinge zu löschen, Werden euch viele
+              Fehlermeldungen begegnet sein, versucht, diese zu lesen und
+              interpretieren, was euch der compiler hier sagen will.
+    \end{enumerate}
+
+    \inputcpp{fehler5.cpp}
+\end{spiel}

--- a/basics/funktionen.tex
+++ b/basics/funktionen.tex
@@ -11,7 +11,7 @@ Für eine Funktion \cppinline{my_func}, die  $x^n$ berechnen soll, könnte eine 
 \[
 	\smashoperator{\mathop{\underbrace{\text{\cppinline{double}}}}_{\text{Rückgabetyp}}}\quad
 	\smashoperator{\mathop{\overbrace{\text{\cppinline{my_func}}}}^{\text{Name}}}
-	(\smashoperator{\mathop{\underbrace{\text{\cppinline{double x}}}}_{\text{Paramter 1}}},\ 
+	(\smashoperator{\mathop{\underbrace{\text{\cppinline{double x}}}}_{\text{Paramter 1}}},\
 	\smashoperator{\mathop{\overbrace{\text{\cppinline{int n}}}^{\text{Paramter 2}}}})
 \]
 %sorry etwas hässlich
@@ -43,7 +43,7 @@ Die Collatz-Vermutung\footnote{\url{https://de.wikipedia.org/wiki/Collatz-Vermut
 \[
 	x_n =
 	\begin{cases}
-		\frac{x_{n-1}}{2} & x_{n-1} \text{ ist gerade} \\
+		\frac{x_{n-1}}{2}   & x_{n-1} \text{ ist gerade}   \\
 		3 \cdot x_{n-1} + 1 & x_{n-1} \text{ ist ungerade}
 	\end{cases}
 \]
@@ -51,38 +51,40 @@ dass jeder Startwert $x_1$ aus den natürlichen Zahlen nach endlich vielen Schri
 Zum Beispiel für den Startwert $x_1 = 42$:
 
 \[
-    42 \mapsto 21 \mapsto 64 \mapsto 32 \mapsto 16 \mapsto 8 \mapsto 4 \mapsto 2 \mapsto 1 \mapsto 4 \mapsto 2 \mapsto 1 \mapsto \ldots
+	42 \mapsto 21 \mapsto 64 \mapsto 32 \mapsto 16 \mapsto 8 \mapsto 4 \mapsto 2 \mapsto 1 \mapsto 4 \mapsto 2 \mapsto 1 \mapsto \ldots
 \]
 
 Wenn nun die Frage aufkommt was die nächsten Folgenglieder von verschiedenen Zahlen sind, wäre ein möglicher Lösungsweg eine Funktion zu schreiben, die der Nutzerin die nächste Zahl in dieser Folge zurückgibt.
 
 \inputcpp{funktion.cpp}
 
-\textbf{Praxis:}\footnote{In dieser Lektion gibt es ein paar mehr Aufgaben als in anderen Lektionen, lasst euch davon nicht entmutigen!}
-\begin{enumerate}
-	\item Verändert das Programm in \texttt{funktion.cpp} so, dass es nicht die einzelnen Zahlen \texttt{x1}, \texttt{x2} und \texttt{x3}, sondern die Summe dieser ausgibt.
-%Wirkt wie Kinderkram nicht zum Funktionskapitel, möchte aber nochmal den Unterschied zwischen Ausgabe und Rückgabe dadurch nochmal klarer machen
-	\item Kompiliert das angepasste Programm und lasst es im debugger Schritt für Schritt durchlaufen, setzt dafür wieder einen breakpoint für die \texttt{main}-Funktion.
-	    Sobald der debugger euch anzeigt, als nächstes die Funktion ausführen zu wollen, \texttt{step} statt \texttt{next} aufrufen, sodass der debugger in die Funktion hineinspringt.
-	\item Schreibt eine Funktion die ein \texttt{double} entgegen nimmt und das Quadrat davon zurück gibt.
-	(Hierbei sollt ihr keine Pakete wie \texttt{math.h} oder \texttt{cmath} benutzen.)
-\end{enumerate}
+\begin{praxis}\footnote{In dieser Lektion gibt es ein paar mehr Aufgaben als in anderen Lektionen, lasst euch davon nicht entmutigen!}
+	\begin{enumerate}
+		\item Verändert das Programm in \texttt{funktion.cpp} so, dass es nicht die einzelnen Zahlen \texttt{x1}, \texttt{x2} und \texttt{x3}, sondern die Summe dieser ausgibt.
+		      %Wirkt wie Kinderkram nicht zum Funktionskapitel, möchte aber nochmal den Unterschied zwischen Ausgabe und Rückgabe dadurch nochmal klarer machen
+		\item Kompiliert das angepasste Programm und lasst es im debugger Schritt für Schritt durchlaufen, setzt dafür wieder einen breakpoint für die \texttt{main}-Funktion.
+		      Sobald der debugger euch anzeigt, als nächstes die Funktion ausführen zu wollen, \texttt{step} statt \texttt{next} aufrufen, sodass der debugger in die Funktion hineinspringt.
+		\item Schreibt eine Funktion die ein \texttt{double} entgegen nimmt und das Quadrat davon zurück gibt.
+		      (Hierbei sollt ihr keine Pakete wie \texttt{math.h} oder \texttt{cmath} benutzen.)
+	\end{enumerate}
+\end{praxis}
 
-\textbf{Spiel:}
-\begin{enumerate}
-	\item Schreibt eine Funktion (nach der Funktion \texttt{collatz} und vor \texttt{main}), die einen \texttt{int} entgegen nimmt und die Anzahl der Schritte bestimmt bis die Folge bei der 1 angekommen ist und diese als \texttt{int} zurückgibt.
-	(Die Funktion sollte also die Signatur \cppinline{int schritte(int x)} haben.)
-	Probiert die Funktion aus.
-	\item Versucht jetzt zwei Zahlen von der Nutzerin entgegen zu nehmen und vergleicht mithilfe von der gerade geschriebenen Funktion, welche Zahl mehr Schritte bis zur 1 braucht.
-    \item Was passiert, wenn ihr in einer Funktion den \texttt{return}-Ausdruck vor dem Ende eurer Funktion benutzt?
-    \item Vertauscht in \texttt{funktion.cpp} die Funktion \texttt{collatz} mit der Funktion \texttt{main} (verschiebt also die gesamte Funktion \texttt{collatz} an das Ende der Datei).
-        Versucht, die Datei zu kompilieren.
-        Was ist die Fehlermeldung des Compilers?
-    \item Verschiebt die Funktion \texttt{collatz} \emph{in} die \texttt{main}-Funktion (also irgendwo nach der öffnenden geschweiften Klammern, aber vor die dazu gehörige schließende).
-        Versucht, die Datei zu kompilieren. Was ist die Fehlermeldung des Compilers?
-    \item Implementiert die Funktion, die $x^n$ umsetzt, ignoriert dabei zunächst negative Exponenten. \\
-        (Wie in Praxis 3, sollt ihr auch hier keine vorgefertigten Pakete benutzen. \emph{Tipp:} Die Signatur ist bereits oben gegeben, für den Funktionsrumpf könnten sich Schleifen eignen.)
-    \item Eure Funktion kann sich auch selbst aufrufen. Versucht damit eure Funktion auf negative Exponenten zu erweitern, indem ihr benutzt, dass gilt $x^{-n} = \Bigl(\frac{1.0}{x}\Bigr)^n$.
-    \item Schaut euch eure bisherigen Lösungen an.
-        Findet ihr noch häufiger Stellen, an denen ihr einzelne Teilprogramme in Funktionen auslagern könnt?
-\end{enumerate}
+\begin{spiel}
+	\begin{enumerate}
+		\item Schreibt eine Funktion (nach der Funktion \texttt{collatz} und vor \texttt{main}), die einen \texttt{int} entgegen nimmt und die Anzahl der Schritte bestimmt bis die Folge bei der 1 angekommen ist und diese als \texttt{int} zurückgibt.
+		      (Die Funktion sollte also die Signatur \cppinline{int schritte(int x)} haben.)
+		      Probiert die Funktion aus.
+		\item Versucht jetzt zwei Zahlen von der Nutzerin entgegen zu nehmen und vergleicht mithilfe von der gerade geschriebenen Funktion, welche Zahl mehr Schritte bis zur 1 braucht.
+		\item Was passiert, wenn ihr in einer Funktion den \texttt{return}-Ausdruck vor dem Ende eurer Funktion benutzt?
+		\item Vertauscht in \texttt{funktion.cpp} die Funktion \texttt{collatz} mit der Funktion \texttt{main} (verschiebt also die gesamte Funktion \texttt{collatz} an das Ende der Datei).
+		      Versucht, die Datei zu kompilieren.
+		      Was ist die Fehlermeldung des Compilers?
+		\item Verschiebt die Funktion \texttt{collatz} \emph{in} die \texttt{main}-Funktion (also irgendwo nach der öffnenden geschweiften Klammern, aber vor die dazu gehörige schließende).
+		      Versucht, die Datei zu kompilieren. Was ist die Fehlermeldung des Compilers?
+		\item Implementiert die Funktion, die $x^n$ umsetzt, ignoriert dabei zunächst negative Exponenten. \\
+		      (Wie in Praxis 3, sollt ihr auch hier keine vorgefertigten Pakete benutzen. \emph{Tipp:} Die Signatur ist bereits oben gegeben, für den Funktionsrumpf könnten sich Schleifen eignen.)
+		\item Eure Funktion kann sich auch selbst aufrufen. Versucht damit eure Funktion auf negative Exponenten zu erweitern, indem ihr benutzt, dass gilt $x^{-n} = \Bigl(\frac{1.0}{x}\Bigr)^n$.
+		\item Schaut euch eure bisherigen Lösungen an.
+		      Findet ihr noch häufiger Stellen, an denen ihr einzelne Teilprogramme in Funktionen auslagern könnt?
+	\end{enumerate}
+\end{spiel}

--- a/basics/gdb.tex
+++ b/basics/gdb.tex
@@ -42,34 +42,37 @@ g++ -O0 -g3 -o debugger debugger.cpp
 \end{minted}
 (Beachtet, dass im ersten Parameter erst ein großer Buchstabe o, dann eine 0 stehen)
 \inputcpp{debugger.cpp}
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Kompiliert das Programm mit den neuen Optionen für den debugger. Ihr
-        könnt es dann mittels \verb|gdb ./debugger| im gdb starten. Ihr solltet
-        nun ein wenig Text ausgegeben bekommen und einen anderen prompt
-        (\texttt{(gdb)}). Ihr könnt den debugger jederzeit wieder verlassen,
-        indem ihr \texttt{quit} eingebt (falls ihr gefragt werdet, ob ihr euch
-        sicher seid, gebt \texttt{y} ein und drückt enter)
-    \item Zu allererst müssen wir einen so genannten \emph{breakpoint} setzen,
-        das ist ein Punkt im Programmablauf, an dem es stoppen soll, damit wir
-        entscheiden können, was wir tun wollen. \texttt{main} ist für die
-        meisten unserer Programme eine sichere Wahl:
-        \mint{text}|break main|
-        Dann können wir das Programm mit \texttt{run} starten. Wir sollten die
-        erste Anweisung unseres Programmes angezeigt bekommen.
-    \item Der Debugger wird euch jetzt immer sagen, welches die nächste
-        Anweisung ist, die er ausführen möchte. Mit \texttt{next} könnt ihr sie
-        ausführen lassen, mit \texttt{print a} könnt ihr euch den Inhalt von
-        \texttt{a} zu diesem Zeitpunkt anschauen, mit \texttt{print b} den von
-        \texttt{b} und so weiter. Geht das Programm Schritt für Schritt durch
-        und lasst euch die Werte von \texttt{a}, \texttt{b} und \texttt{c} in
-        jedem Schritt ausgeben. Wenn der debugger euch sagt, dass euer Programm
-        beendet wurde, gebt \texttt{quit} ein und beendet ihn.
-\end{enumerate}
 
-\textbf{Spiel:}
-\begin{enumerate}
-    \item Ihr habt nun schon einige Programme kennen gelernt. Kompiliert sie
-        für den Debugger neu und untersucht sie genauso wie obiges Programm,
-        solange ihr Lust habt.
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Kompiliert das Programm mit den neuen Optionen für den debugger. Ihr
+              könnt es dann mittels \verb|gdb ./debugger| im gdb starten. Ihr solltet
+              nun ein wenig Text ausgegeben bekommen und einen anderen prompt
+              (\texttt{(gdb)}). Ihr könnt den debugger jederzeit wieder verlassen,
+              indem ihr \texttt{quit} eingebt (falls ihr gefragt werdet, ob ihr euch
+              sicher seid, gebt \texttt{y} ein und drückt enter)
+        \item Zu allererst müssen wir einen so genannten \emph{breakpoint} setzen,
+              das ist ein Punkt im Programmablauf, an dem es stoppen soll, damit wir
+              entscheiden können, was wir tun wollen. \texttt{main} ist für die
+              meisten unserer Programme eine sichere Wahl:
+              \mint{text}|break main|
+              Dann können wir das Programm mit \texttt{run} starten. Wir sollten die
+              erste Anweisung unseres Programmes angezeigt bekommen.
+        \item Der Debugger wird euch jetzt immer sagen, welches die nächste
+              Anweisung ist, die er ausführen möchte. Mit \texttt{next} könnt ihr sie
+              ausführen lassen, mit \texttt{print a} könnt ihr euch den Inhalt von
+              \texttt{a} zu diesem Zeitpunkt anschauen, mit \texttt{print b} den von
+              \texttt{b} und so weiter. Geht das Programm Schritt für Schritt durch
+              und lasst euch die Werte von \texttt{a}, \texttt{b} und \texttt{c} in
+              jedem Schritt ausgeben. Wenn der debugger euch sagt, dass euer Programm
+              beendet wurde, gebt \texttt{quit} ein und beendet ihn.
+    \end{enumerate}
+\end{praxis}
+
+\begin{spiel}
+    \begin{enumerate}
+        \item Ihr habt nun schon einige Programme kennen gelernt. Kompiliert sie
+              für den Debugger neu und untersucht sie genauso wie obiges Programm,
+              solange ihr Lust habt.
+    \end{enumerate}
+\end{spiel}

--- a/basics/hello_world.tex
+++ b/basics/hello_world.tex
@@ -37,19 +37,19 @@ benutzen wollen, heißt \texttt{g++}.
 Dem Compiler übergeben wir die zu kompilierende Datei als Parameter, indem wir
 sie im Terminal dahinter schreiben:
 \begin{center}
-\texttt{g++ zuKompilierendeDatei.cpp}
+    \texttt{g++ zuKompilierendeDatei.cpp}
 \end{center}
 Wir können zusätzlich den Namen der Ausgabedatei festlegen, indem wir vor diese
 ein \texttt{-o} (o für output) schreiben:
 \begin{center}
-\texttt{g++ -o outputDatei zuKompilierendeDatei.cpp}
+    \texttt{g++ -o outputDatei zuKompilierendeDatei.cpp}
 \end{center}
 
 Nachdem \texttt{g++} uns also ein Maschinencodefile \texttt{outputDatei}
 erzeugt hat, können wir es zur Ausführung bringen. Wir tun das, indem wir in
 einem Terminal
 \begin{center}
-	\texttt{./outputDatei}
+    \texttt{./outputDatei}
 \end{center}
 eingeben, also einen Punkt, ein Slash und dann den Dateinamen.
 
@@ -69,36 +69,38 @@ Diagramm:
     }
 \end{center}
 
-\textbf{Praxis:}
-\begin{enumerate}
-	\item Öffnet ein Terminal (Konsole), ihr findet dies oben links unter „Applications“ als „Terminal Emulator“ oder mittig unten als das zweite Symbol von links.
-    \item Wechselt in das Verzeichnis \texttt{vorkurs/lektion01}, indem ihr
-		\texttt{cd vorkurs/lektion01}\footnote{was dieser Befehl genau tut und wie er funktioniert, erfahrt ihr in Lektion 2} eingebt und enter drückt.
-    \item In diesem Verzeichnis liegt eine Datei \texttt{helloworld.cpp}.
-        Benutzt \texttt{g++}, um diese zu einer Datei \texttt{hello} zu
-        kompilieren. Orientiert euch dazu an den Befehlen von oben.
-    \item Führt die Datei \texttt{hello} aus.
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Öffnet ein Terminal (Konsole), ihr findet dies oben links unter „Applications“ als „Terminal Emulator“ oder mittig unten als das zweite Symbol von links.
+        \item Wechselt in das Verzeichnis \texttt{vorkurs/lektion01}, indem ihr
+              \texttt{cd vorkurs/lektion01}\footnote{was dieser Befehl genau tut und wie er funktioniert, erfahrt ihr in Lektion 2} eingebt und enter drückt.
+        \item In diesem Verzeichnis liegt eine Datei \texttt{helloworld.cpp}.
+              Benutzt \texttt{g++}, um diese zu einer Datei \texttt{hello} zu
+              kompilieren. Orientiert euch dazu an den Befehlen von oben.
+        \item Führt die Datei \texttt{hello} aus.
+    \end{enumerate}
+\end{praxis}
 
 \inputcpp{helloworld.cpp}
 
-\textbf{Spiel:}
+\begin{spiel}
 
-Ihr könnt nun versuchen, den Quellcode selbst zu verändern und damit ein wenig
-herumzuspielen. Öffnet dazu einen Editor (in den Anwendungen findet ihr z.B.
-unter „Zubehör“ den Editor gedit) und öffnet die Datei
-\texttt{vorkurs/lektion01/helloworld.cpp}\footnote{entweder mittels
-\glqq{}Datei/Öffnen\grqq{} in gedit oder über das Terminal mittels \texttt{gedit
-helloworld.cpp}}. Denkt daran, nach jeder Änderung die Datei zu speichern und
-im Terminal neu zu kompilieren und auszuführen.
+    Ihr könnt nun versuchen, den Quellcode selbst zu verändern und damit ein wenig
+    herumzuspielen. Öffnet dazu einen Editor (in den Anwendungen findet ihr z.B.
+    unter „Zubehör“ den Editor gedit) und öffnet die Datei
+    \texttt{vorkurs/lektion01/helloworld.cpp}\footnote{entweder mittels
+        \glqq{}Datei/Öffnen\grqq{} in gedit oder über das Terminal mittels \texttt{gedit
+            helloworld.cpp}}. Denkt daran, nach jeder Änderung die Datei zu speichern und
+    im Terminal neu zu kompilieren und auszuführen.
 
-Dinge, die ihr ausprobieren könntet sind zum Beispiel:
-\begin{enumerate}
-    \item Was passiert, wenn ihr „Hello world!“ in etwas anderes ändert?
-    \item Was passiert, wenn ihr die erste Zeile löscht (der Originalquellcode
-        ist in diesem pdf enthalten, ihr könnt sie also später wieder
-        herstellen)?
-    \item Was passiert, wenn ihr das „\verb|<< std::endl|“ löscht?
-    \item Wie könnte man mehrere Sätze ausgeben? Wie könnte man mehrere Zeilen
-        ausgeben?
-\end{enumerate}
+    Dinge, die ihr ausprobieren könntet sind zum Beispiel:
+    \begin{enumerate}
+        \item Was passiert, wenn ihr „Hello world!“ in etwas anderes ändert?
+        \item Was passiert, wenn ihr die erste Zeile löscht (der Originalquellcode
+              ist in diesem pdf enthalten, ihr könnt sie also später wieder
+              herstellen)?
+        \item Was passiert, wenn ihr das „\verb|<< std::endl|“ löscht?
+        \item Wie könnte man mehrere Sätze ausgeben? Wie könnte man mehrere Zeilen
+              ausgeben?
+    \end{enumerate}
+\end{spiel}

--- a/basics/input.tex
+++ b/basics/input.tex
@@ -24,23 +24,24 @@ sich nicht die Mühe gemacht, extra eine grafische Oberfläche zu entwickeln.
 
 Nun aber direkt zur Praxis:
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Öffnet die Datei \texttt{vorkurs/lektion03/helloyou.cpp} in eurem Texteditor
-    \item Öffnet ein Terminal und wechselt in das Verzeichnis \texttt{vorkurs/lektion03}
-    \item Kompiliert im Terminal die Datei (\texttt{g++ -o helloyou
-        helloyou.cpp}) und führt sie aus (\texttt{./helloyou})
-    \item Versucht verschiedene Eingaben an das Programm und beobachtet, was passiert
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Öffnet die Datei \texttt{vorkurs/lektion03/helloyou.cpp} in eurem Texteditor
+        \item Öffnet ein Terminal und wechselt in das Verzeichnis \texttt{vorkurs/lektion03}
+        \item Kompiliert im Terminal die Datei (\texttt{g++ -o helloyou
+                  helloyou.cpp}) und führt sie aus (\texttt{./helloyou})
+        \item Versucht verschiedene Eingaben an das Programm und beobachtet, was passiert
+    \end{enumerate}
 
-\inputcpp{helloyou.cpp}
+    \inputcpp{helloyou.cpp}
+\end{praxis}
 
-\textbf{Spiel:}
-
-\begin{enumerate}
-    \item Versucht, zu verstehen, was die einzelnen Teile des Programms tun. An
-        welcher Stelle erfolgt die Eingabe? Was passiert dann damit?
-    \item Erweitert das Programm um eigene Fragen und Ausgaben. Vergesst nicht,
-        dass ihr das Programm nach jeder Änderung neu kompilieren und testen
-        müsst.
-\end{enumerate}
+\begin{spiel}
+    \begin{enumerate}
+        \item Versucht, zu verstehen, was die einzelnen Teile des Programms tun. An
+              welcher Stelle erfolgt die Eingabe? Was passiert dann damit?
+        \item Erweitert das Programm um eigene Fragen und Ausgaben. Vergesst nicht,
+              dass ihr das Programm nach jeder Änderung neu kompilieren und testen
+              müsst.
+    \end{enumerate}
+\end{spiel}

--- a/basics/konsole.tex
+++ b/basics/konsole.tex
@@ -39,29 +39,31 @@ könnt ihr den Befehl \texttt{man} (für „Manual“) geben, gefolgt von dem Be
 zu dem ihr Hilfe braucht (über \texttt{man} werden wir später noch
 ausführlicher reden).
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Öffnet ein Terminal und gebt die folgenden Befehle ein:
-    \inputshell{basics.sh}
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Öffnet ein Terminal und gebt die folgenden Befehle ein:
+              \inputshell{basics.sh}
+    \end{enumerate}
+\end{praxis}
 
-\textbf{Spiel:}
-\begin{enumerate}
-    \item Versucht selbst, euer Nutzerverzeichnis (\emph{home}) zu navigieren.
-        Wie viele Lektionen hat der Vorkurs?
-    \item Was passiert, wenn ihr euer Homeverzeichnis verlasst (\texttt{cd ..}
-        während ihr darin seid)?
-	\item Versucht in der manpage von ls (\texttt{man ls}) zu stöbern und die
-		verschiedenen Parameter, mit denen ihr das Verhalten steuern könnt zu
-		erforschen. Findet ihr heraus, wie ihr den Verzeichnisinhalt in einem
-		langen Listenformat (long listing format) anzeigen lassen könnt (in dem
-		unter anderem auch die Dateigröße zu jeder Datei steht)
-\end{enumerate}
+\begin{spiel}
+    \begin{enumerate}
+        \item Versucht selbst, euer Nutzerverzeichnis (\emph{home}) zu navigieren.
+              Wie viele Lektionen hat der Vorkurs?
+        \item Was passiert, wenn ihr euer Homeverzeichnis verlasst (\texttt{cd ..}
+              während ihr darin seid)?
+        \item Versucht in der manpage von ls (\texttt{man ls}) zu stöbern und die
+              verschiedenen Parameter, mit denen ihr das Verhalten steuern könnt zu
+              erforschen. Findet ihr heraus, wie ihr den Verzeichnisinhalt in einem
+              langen Listenformat (long listing format) anzeigen lassen könnt (in dem
+              unter anderem auch die Dateigröße zu jeder Datei steht)
+    \end{enumerate}
 
-\vspace{5em}
+    \vspace{5em}
 
-Falls euch das alles verwirrt, fragt entweder direkt nach oder wartet auf
-Lektion 6, da geht es zu Manpages noch mal ins Detail.
+    Falls euch das alles verwirrt, fragt entweder direkt nach oder wartet auf
+    Lektion 6, da geht es zu Manpages noch mal ins Detail.
 
-Ihr findet unter \url{http://blog.ezelo.de/basic-linux-befehle/} auch noch mal
-die wichtigsten Befehle zusammengefasst.
+    Ihr findet unter \url{http://blog.ezelo.de/basic-linux-befehle/} auch noch mal
+    die wichtigsten Befehle zusammengefasst.
+\end{spiel}

--- a/basics/kontrollfluss.tex
+++ b/basics/kontrollfluss.tex
@@ -37,21 +37,21 @@ Verhaltens eines Programms von den Eingaben, bezeichnen wir als
 \emph{Kontrollfluss}, man kann das mit einem Diagramm verdeutlichen:
 
 \begin{center}
-    \begin{tikzpicture}[auto, node distance=3cm,>=latex']
-        \tikzstyle{block} = [draw, fill=blue!20, rectangle, minimum height=3em, minimum width=6em]
+      \begin{tikzpicture}[auto, node distance=3cm,>=latex']
+            \tikzstyle{block} = [draw, fill=blue!20, rectangle, minimum height=3em, minimum width=6em]
 
-        \node [block] (start) {Input};
-        \node [block, right of=start] (if) { $a=0$? };
-        \node [block, right of=if, node distance=4cm] (fehler) { Gib Fehler aus };
-        \node [block, below of=fehler,node distance =  2cm] (quotient) { Gib Quotient aus };
-        \node [block, right of=fehler, node distance = 3.5cm] (ende) { Ende };
+            \node [block] (start) {Input};
+            \node [block, right of=start] (if) { $a=0$? };
+            \node [block, right of=if, node distance=4cm] (fehler) { Gib Fehler aus };
+            \node [block, below of=fehler,node distance =  2cm] (quotient) { Gib Quotient aus };
+            \node [block, right of=fehler, node distance = 3.5cm] (ende) { Ende };
 
-        \draw [->] (start) -- node {} (if);
-        \draw [->] (if) -- node {\texttt{ja}} (fehler);
-        \draw [->] (if.south) |- node [above, near end] {\texttt{nein}} (quotient);
-        \draw [->] (quotient) -| node {} (ende);
-        \draw [->] (fehler) -- node {} (ende);
-    \end{tikzpicture}
+            \draw [->] (start) -- node {} (if);
+            \draw [->] (if) -- node {\texttt{ja}} (fehler);
+            \draw [->] (if.south) |- node [above, near end] {\texttt{nein}} (quotient);
+            \draw [->] (quotient) -| node {} (ende);
+            \draw [->] (fehler) -- node {} (ende);
+      \end{tikzpicture}
 \end{center}
 
 Die einfachste Möglichkeit, den Kontrollfluss zu ändern, besteht in so
@@ -68,29 +68,31 @@ getrennte Operatoren für Vergleiche und Zuweisungen - Doppelte
 Gleichheitszeichen bedeuten Vergleich („sind diese beiden gleich?“), ein
 einfaches Gleichheitszeichen bedeutet Zuweisung („mache diese beiden gleich!“).
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Kompiliert \texttt{if.cpp} für den debugger und lasst das Programm im
-          gdb laufen. Geht Schritt für Schritt durch das Programm, mit
-          verschiedenen Eingaben (wenn ihr am Ende des Programms angekommen seid,
-          könnt ihr es mit einem erneuten „run“ neu starten)
-    \item Nutzt Google, um herauszufinden, welche anderen Vergleichsoperatoren
-          es in \Cpp noch gibt. Versucht, das Programm so zu verändern, dass es
-          auf Ungleichheit testet, statt auf Gleichheit (sich sonst aber genauso
-          verhält).
-    \item Wie würdet ihr testen, ob zwei Zahlen durch einander teilbar sind
-          (Tipp: Ihr kennt bereits die Division mit Rest in \Cpp (modulo))?
-          Schreibt ein Programm, welches zwei Zahlen von der Nutzerin entgegen
-          nimmt und ausgibt, ob die zweite Zahl die erste teilt.
-\end{enumerate}
+\begin{praxis}
+      \begin{enumerate}
+            \item Kompiliert \texttt{if.cpp} für den debugger und lasst das Programm im
+                  gdb laufen. Geht Schritt für Schritt durch das Programm, mit
+                  verschiedenen Eingaben (wenn ihr am Ende des Programms angekommen seid,
+                  könnt ihr es mit einem erneuten „run“ neu starten)
+            \item Nutzt Google, um herauszufinden, welche anderen Vergleichsoperatoren
+                  es in \Cpp noch gibt. Versucht, das Programm so zu verändern, dass es
+                  auf Ungleichheit testet, statt auf Gleichheit (sich sonst aber genauso
+                  verhält).
+            \item Wie würdet ihr testen, ob zwei Zahlen durch einander teilbar sind
+                  (Tipp: Ihr kennt bereits die Division mit Rest in \Cpp (modulo))?
+                  Schreibt ein Programm, welches zwei Zahlen von der Nutzerin entgegen
+                  nimmt und ausgibt, ob die zweite Zahl die erste teilt.
+      \end{enumerate}
+\end{praxis}
 
-\textbf{Spiel:}
-\begin{enumerate}
-    \item Testet mit verschiedenen Eingaben, was passiert, wenn ihr in
-          \texttt{if.cpp} statt zwei Gleichheitszeichen nur eines benutzt.
-          Benutzt den debugger, um euch den Inhalt von \texttt{b} vor und nach
-          dem Test anzuschauen.
-    \item Schreibt ein Programm, welches die Benutzerin fragt, wie sie heißt.
-          Gibt sie euren eigenen Namen ein, soll das Programm begeistert über die
-          Namensgleichheit sein, sonst sie einfach begrüßen.
-\end{enumerate}
+\begin{spiel}
+      \begin{enumerate}
+            \item Testet mit verschiedenen Eingaben, was passiert, wenn ihr in
+                  \texttt{if.cpp} statt zwei Gleichheitszeichen nur eines benutzt.
+                  Benutzt den debugger, um euch den Inhalt von \texttt{b} vor und nach
+                  dem Test anzuschauen.
+            \item Schreibt ein Programm, welches die Benutzerin fragt, wie sie heißt.
+                  Gibt sie euren eigenen Namen ein, soll das Programm begeistert über die
+                  Namensgleichheit sein, sonst sie einfach begrüßen.
+      \end{enumerate}
+\end{spiel}

--- a/basics/linker.tex
+++ b/basics/linker.tex
@@ -85,35 +85,36 @@ dass wir eine ausführbare Datei wünschen (da wir weder \texttt{-c} noch
 \texttt{-S} angegeben haben) und dass er dafür kompilieren, assemblieren und
 linken muss (da wir ihm eine \texttt{.cpp} Datei gegeben haben). Genauso konnte
 er in der vorigen Lektion raten, dass \texttt{g++ -o tictactoe tictactoe.cpp
-tictactoe.o} heißt, dass wir eine ausführbare Datei wollen, die aus einem
+    tictactoe.o} heißt, dass wir eine ausführbare Datei wollen, die aus einem
 kompilierten und assemblierten \texttt{tictactoe.cpp} zusammen gelinkt mit
 \texttt{tictactoe.o} bestehen soll.
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item \texttt{assemble.cpp} enthält ein kleines (ziemlich nutzloses)
-        Programm, welches zwei Zahlen addiert und das Ergebnis ausgibt.
-        Kompiliert es (nun nur der erste Schritt in dem Diagramm, nicht so, wie
-        in den vergangenen Lektionen) und schaut euch das resultierende
-        \texttt{.S}-file in einem Editor an. Ihr müsst nicht verstehen,
-				was genau hier überall passiert, aber vielleicht findet ihr ja die
-				\texttt{main}-Funktion, die Definition der Variablen und die Addition?
+\begin{praxis}
+    \begin{enumerate}
+        \item \texttt{assemble.cpp} enthält ein kleines (ziemlich nutzloses)
+              Programm, welches zwei Zahlen addiert und das Ergebnis ausgibt.
+              Kompiliert es (nun nur der erste Schritt in dem Diagramm, nicht so, wie
+              in den vergangenen Lektionen) und schaut euch das resultierende
+              \texttt{.S}-file in einem Editor an. Ihr müsst nicht verstehen,
+              was genau hier überall passiert, aber vielleicht findet ihr ja die
+              \texttt{main}-Funktion, die Definition der Variablen und die Addition?
 
-        Wir können nun mal Optimierung anschalten -- gebt dazu zusätzlich den
-        Parameter \texttt{-O3} direkt nach dem \texttt{g++} an. Schaut euch das
-        \texttt{.S}-file nun wieder im Editor an. Was fällt euch
-				(im Vergleich zu vorher) auf?
-    \item Assembliert eines der im vorigen Schritt erzeugten \texttt{.S} files
-        in ein \texttt{.o}-File.
-    \item Benennt in einem eurer bisherigen Programme die
-        \texttt{main}-Funktion um und versucht, es zu kompilieren (wie in den
-        bisherigen Lektionen, also alle Schritte auf einmal). Schaut euch die
-        resultierenden Fehlermeldungen an. Wo wird euch der Linkerfehler
-        ausgegeben?
-    \item Macht die Umbenennung wieder rückgängig und kompiliert das Programm
-        erneut -- übergebt aber dieses mal den Quellcode doppelt (also z.B.
-        \texttt{g++ -o helloworld helloworld.cpp helloworld.cpp}). Was
-        beobachtet ihr? Könnt ihr die Beobachtung erklären?
-\end{enumerate}
+              Wir können nun mal Optimierung anschalten -- gebt dazu zusätzlich den
+              Parameter \texttt{-O3} direkt nach dem \texttt{g++} an. Schaut euch das
+              \texttt{.S}-file nun wieder im Editor an. Was fällt euch
+              (im Vergleich zu vorher) auf?
+        \item Assembliert eines der im vorigen Schritt erzeugten \texttt{.S} files
+              in ein \texttt{.o}-File.
+        \item Benennt in einem eurer bisherigen Programme die
+              \texttt{main}-Funktion um und versucht, es zu kompilieren (wie in den
+              bisherigen Lektionen, also alle Schritte auf einmal). Schaut euch die
+              resultierenden Fehlermeldungen an. Wo wird euch der Linkerfehler
+              ausgegeben?
+        \item Macht die Umbenennung wieder rückgängig und kompiliert das Programm
+              erneut -- übergebt aber dieses mal den Quellcode doppelt (also z.B.
+              \texttt{g++ -o helloworld helloworld.cpp helloworld.cpp}). Was
+              beobachtet ihr? Könnt ihr die Beobachtung erklären?
+    \end{enumerate}
 
-\inputcpp{assemble.cpp}
+    \inputcpp{assemble.cpp}
+\end{praxis}

--- a/basics/manpages.tex
+++ b/basics/manpages.tex
@@ -9,89 +9,90 @@ page am Besten konsumiert.
 Wir schauen uns das am Beispiel der Manpage \texttt{man cp} an (\texttt{cp} ist
 der Befehl zum Kopieren von Dateien).
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Öffnet eine Konsole und gebt \texttt{man cp} ein.
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Öffnet eine Konsole und gebt \texttt{man cp} ein.
+    \end{enumerate}
 
-Die man page besteht aus mehreren \emph{Sections}. Welche sections genau es
-gibt, hängt von der man page ab, aber meistens gibt es mindestens die folgenden
-sections:
-\begin{description}
-    \item[\texttt{NAME}]
-        Gibt euch den Namen des Befehls und eine Einzeilige Beschreibung an
-    \item[\texttt{SYNOPSIS}]
-        Gibt euch die generelle Benutzung des Befehls an. In diesem Fall gibt
-        es drei mögliche Formen. Allen gemein ist, dass man zunächst
-        \texttt{cp} eingibt, darauf folgen Optionen. Wie der Rest interpretiert
-        wird, hängt dann vom Rest ab. Werden zwei weitere Parameter angegeben,
-        wird der erste als Quelle, der zweite als Ziel interpretiert (erste
-        Form). Werden mehr Parameter angegeben, wird das letzte als
-        Verzeichnis, in das man alle anderen kopieren will interpretiert
-        (zweite Form). In der dritten Form (wenn \texttt{-t} angegeben wird)
-        wird hingegen der \emph{erste} Parameter als das Zielverzeichnis
-        interpretiert, in das alle anderen Dateien kopiert wird.
+    Die man page besteht aus mehreren \emph{Sections}. Welche sections genau es
+    gibt, hängt von der man page ab, aber meistens gibt es mindestens die folgenden
+    sections:
+    \begin{description}
+        \item[\texttt{NAME}]
+              Gibt euch den Namen des Befehls und eine Einzeilige Beschreibung an
+        \item[\texttt{SYNOPSIS}]
+              Gibt euch die generelle Benutzung des Befehls an. In diesem Fall gibt
+              es drei mögliche Formen. Allen gemein ist, dass man zunächst
+              \texttt{cp} eingibt, darauf folgen Optionen. Wie der Rest interpretiert
+              wird, hängt dann vom Rest ab. Werden zwei weitere Parameter angegeben,
+              wird der erste als Quelle, der zweite als Ziel interpretiert (erste
+              Form). Werden mehr Parameter angegeben, wird das letzte als
+              Verzeichnis, in das man alle anderen kopieren will interpretiert
+              (zweite Form). In der dritten Form (wenn \texttt{-t} angegeben wird)
+              wird hingegen der \emph{erste} Parameter als das Zielverzeichnis
+              interpretiert, in das alle anderen Dateien kopiert wird.
 
-        Es gibt eine Vielzahl von Konventionen für diesen Bereich, eckige
-        Klammern bedeuten z.B. dass dieser Teil auch weggelassen werden darf,
-        drei Punkte bedeuten, dass hier mehrere solche Dinge stehen können.
+              Es gibt eine Vielzahl von Konventionen für diesen Bereich, eckige
+              Klammern bedeuten z.B. dass dieser Teil auch weggelassen werden darf,
+              drei Punkte bedeuten, dass hier mehrere solche Dinge stehen können.
 
-        Dieser Bereich ist der, der am Interessantesten für euch ist, wenn ihr
-        „einfach schnell wissen wollt, wie es funktioniert“.
-    \item[\texttt{DESCRIPTION}]
-        Hier wird ausführlicher beschrieben, was der Befehl tut. Hier werden
-        auch alle möglichen Optionen beschrieben, die wir dem Befehl bei
-        \texttt{[OPTION]...} mitgeben können. Die wichtigen Informationen
-        stehen meistens irgendwo in diesem Bereich.
-    \item[\texttt{AUTHOR}, \texttt{REPORTING BUGS}, \dots]
-        Hier stehen weitere Hintergrundinformationen, die meistens eher für
-        Entwicklerinnen interessant sind.
-    \item[\texttt{SEE ALSO}]
-        Auch eine wichtige section für euch: Wenn ihr die gewünschte
-        Information nicht gefunden habt, oder ihr nicht den richtigen Befehl
-        gefunden habt, stehen hier manchmal verwandte Befehle oder Quellen
-        weiterer Informationen.
-\end{description}
+              Dieser Bereich ist der, der am Interessantesten für euch ist, wenn ihr
+              „einfach schnell wissen wollt, wie es funktioniert“.
+        \item[\texttt{DESCRIPTION}]
+              Hier wird ausführlicher beschrieben, was der Befehl tut. Hier werden
+              auch alle möglichen Optionen beschrieben, die wir dem Befehl bei
+              \texttt{[OPTION]...} mitgeben können. Die wichtigen Informationen
+              stehen meistens irgendwo in diesem Bereich.
+        \item[\texttt{AUTHOR}, \texttt{REPORTING BUGS}, \dots]
+              Hier stehen weitere Hintergrundinformationen, die meistens eher für
+              Entwicklerinnen interessant sind.
+        \item[\texttt{SEE ALSO}]
+              Auch eine wichtige section für euch: Wenn ihr die gewünschte
+              Information nicht gefunden habt, oder ihr nicht den richtigen Befehl
+              gefunden habt, stehen hier manchmal verwandte Befehle oder Quellen
+              weiterer Informationen.
+    \end{description}
 
-Man pages sind häufig sehr umfangreich und enthalten viel mehr Informationen,
-als ihr euch gerade wünscht. Es ist nicht immer einfach, die gerade relevanten
-Informationen heraus zu filtern und es gibt nichts frustrierenderes, als einen
-Befehl gerade dringend zu brauchen, aber nicht zu kennen und sich erst durch
-eine lange man page lesen zu müssen.
+    Man pages sind häufig sehr umfangreich und enthalten viel mehr Informationen,
+    als ihr euch gerade wünscht. Es ist nicht immer einfach, die gerade relevanten
+    Informationen heraus zu filtern und es gibt nichts frustrierenderes, als einen
+    Befehl gerade dringend zu brauchen, aber nicht zu kennen und sich erst durch
+    eine lange man page lesen zu müssen.
 
-Dennoch ist es eine sehr hilfreiche Fähigkeit, zu wissen, wie man man pages
-liest und sich einfach in einem ruhigen Moment mal durch die ein oder andere
-man page durch zu lesen. Häufig lernt man dabei neue Dinge, manchmal macht es
-einem das Leben irgendwann sehr viel leichter, sie zu wissen.
+    Dennoch ist es eine sehr hilfreiche Fähigkeit, zu wissen, wie man man pages
+    liest und sich einfach in einem ruhigen Moment mal durch die ein oder andere
+    man page durch zu lesen. Häufig lernt man dabei neue Dinge, manchmal macht es
+    einem das Leben irgendwann sehr viel leichter, sie zu wissen.
 
-Habt von daher Geduld, wenn euch eine wirsche Linux-Expertin auf die Frage, wie
-ihr unter Linux euren Laptop in den Ruhemodus versetzt ein schnelles „man
-pm-suspend“ antwortet. Mit ein bisschen Übung wird euch das tatsächlich
-hinreichend schnell zur richtigen Lösung verhelfen.
+    Habt von daher Geduld, wenn euch eine wirsche Linux-Expertin auf die Frage, wie
+    ihr unter Linux euren Laptop in den Ruhemodus versetzt ein schnelles „man
+    pm-suspend“ antwortet. Mit ein bisschen Übung wird euch das tatsächlich
+    hinreichend schnell zur richtigen Lösung verhelfen.
 
-\textbf{Praxis:}
-\begin{enumerate}[resume]
-    \item Öffnet die man page von \texttt{ls}. Findet die Optionen fürs Lange
-				Listenformat (long listing format), zum Sortieren nach Dateigröße
-				und um auch versteckte Dateien (unter Linux sind das alle, die mit
-				\texttt{.} anfangen) anzuzeigen und probiert sie aus.
-    \item Was ist der Unterschied zwischen \texttt{ls -a} und \texttt{ls -A}?
-        Probiert beides aus. Das ist auf den ersten Blick nicht so leicht zu sehen
-				Fragt uns im einfach wenn ihr es nicht findest.
-    \item Nutzt \texttt{cp} um eine Datei zu kopieren. Sucht euch dafür
-        irgendeine \texttt{.cpp}-Datei aus dem Vorkurs-Programm und kopiert sie
-        in euer Homeverzeichnis (ihr könnt dafür eine Tilde (\texttt{\~})
-        benutzen).
-\end{enumerate}
+    \begin{enumerate}[resume]
+        \item Öffnet die man page von \texttt{ls}. Findet die Optionen fürs Lange
+              Listenformat (long listing format), zum Sortieren nach Dateigröße
+              und um auch versteckte Dateien (unter Linux sind das alle, die mit
+              \texttt{.} anfangen) anzuzeigen und probiert sie aus.
+        \item Was ist der Unterschied zwischen \texttt{ls -a} und \texttt{ls -A}?
+              Probiert beides aus. Das ist auf den ersten Blick nicht so leicht zu sehen
+              Fragt uns im einfach wenn ihr es nicht findest.
+        \item Nutzt \texttt{cp} um eine Datei zu kopieren. Sucht euch dafür
+              irgendeine \texttt{.cpp}-Datei aus dem Vorkurs-Programm und kopiert sie
+              in euer Homeverzeichnis (ihr könnt dafür eine Tilde (\texttt{\~})
+              benutzen).
+    \end{enumerate}
+\end{praxis}
 
-\textbf{Spiel:}
-\begin{enumerate}
-    \item Wie über so gut wie jeden Befehl gibt es auch über \texttt{man} eine
-        manpage. Schaut euch mal \texttt{man man} an.
-    \item Befehle, die für euch im späteren Leben interessant sein könnten sind
-        z.B. \texttt{ls}, \texttt{cp}, \texttt{mkdir}, \texttt{grep}, \texttt{cat},
-        \texttt{echo}, \texttt{mv}, \dots. Ihr könnt ja schon einmal in ein
-        oder zwei dieser manpages hinein schauen, und ein oder zwei Befehle
-        ausprobieren. Aber ihr müsst das jetzt auf keinen fall alles im Kopf
-				behalten.
-\end{enumerate}
+\begin{spiel}
+    \begin{enumerate}
+        \item Wie über so gut wie jeden Befehl gibt es auch über \texttt{man} eine
+              manpage. Schaut euch mal \texttt{man man} an.
+        \item Befehle, die für euch im späteren Leben interessant sein könnten sind
+              z.B. \texttt{ls}, \texttt{cp}, \texttt{mkdir}, \texttt{grep}, \texttt{cat},
+              \texttt{echo}, \texttt{mv}, \dots. Ihr könnt ja schon einmal in ein
+              oder zwei dieser manpages hinein schauen, und ein oder zwei Befehle
+              ausprobieren. Aber ihr müsst das jetzt auf keinen fall alles im Kopf
+              behalten.
+    \end{enumerate}
+\end{spiel}

--- a/basics/rechte.tex
+++ b/basics/rechte.tex
@@ -27,22 +27,22 @@ mithilfe von \texttt{ls -l} anschauen. Der output von \texttt{ls -l} ist in
 mehreren Spalten angeordnet:
 \begin{enumerate}
     \item In der ersten Spalte stehen die Dateiberechtigungen in Form eines 10
-        Zeichen langen Strings. Jedes Zeichen steht dabei für ein permission
-        bit kann dabei entweder ein \texttt{-}, oder ein Buchstabe sein, wobei
-        \texttt{-} bedeutet, dass das entsprechende Bit nicht gesetzt ist. Die
-        Bits bedeuten (von links nach rechts gelesen)
-        \begin{itemize}
-            \item \texttt{\underline{d}irectory}
-            \item \texttt{\underline{r}eadable} für die Eigentümerin
-            \item \texttt{\underline{w}ritable} für die Eigentümerin
-            \item \texttt{e\underline{x}ecutable} für die Eigentümerin
-            \item \texttt{\underline{r}eadable} für die Gruppe
-            \item \texttt{\underline{w}ritable} für die Gruppe
-            \item \texttt{e\underline{x}ecutable} für die Gruppe
-            \item \texttt{\underline{r}eadable} für alle Nutzerinnen
-            \item \texttt{\underline{w}ritable} für alle Nutzerinnen
-            \item \texttt{e\underline{x}ecutable} für alle Nutzerinnen
-        \end{itemize}
+          Zeichen langen Strings. Jedes Zeichen steht dabei für ein permission
+          bit kann dabei entweder ein \texttt{-}, oder ein Buchstabe sein, wobei
+          \texttt{-} bedeutet, dass das entsprechende Bit nicht gesetzt ist. Die
+          Bits bedeuten (von links nach rechts gelesen)
+          \begin{itemize}
+              \item \texttt{\underline{d}irectory}
+              \item \texttt{\underline{r}eadable} für die Eigentümerin
+              \item \texttt{\underline{w}ritable} für die Eigentümerin
+              \item \texttt{e\underline{x}ecutable} für die Eigentümerin
+              \item \texttt{\underline{r}eadable} für die Gruppe
+              \item \texttt{\underline{w}ritable} für die Gruppe
+              \item \texttt{e\underline{x}ecutable} für die Gruppe
+              \item \texttt{\underline{r}eadable} für alle Nutzerinnen
+              \item \texttt{\underline{w}ritable} für alle Nutzerinnen
+              \item \texttt{e\underline{x}ecutable} für alle Nutzerinnen
+          \end{itemize}
     \item Nummer an hardlinks (das braucht euch nicht sonderlich interessieren)
     \item Nutzername der Eigentümerin
     \item Gruppe, der die Datei gehört
@@ -53,31 +53,33 @@ mehreren Spalten angeordnet:
 
 Wenn ihr die Berechtigungen von Dateien ändern wollt, könnt ihr dazu
 \texttt{chmod} benutzen (wenn ihr wissen wollt, wie man es benutzt: \texttt{man
-chmod}), dazu muss sie euch aber gehören. Wenn ihr die Eigentümerin einer Datei
+    chmod}), dazu muss sie euch aber gehören. Wenn ihr die Eigentümerin einer Datei
 ändern wollt, könnt ihr dazu \texttt{chown} nutzen -- dazu müsst ihr aus
 Sicherheitsgründen allerdings Administratorin sein.
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Geht in ein Verzeichnis, in dem eine \texttt{.cpp}-Datei liegt und
-        kompiliert sie. Macht ein \texttt{ls -l} und vergleicht die Rechte der
-        \texttt{.cpp}-Datei mit der kompilierten Datei.
-    \item In der Datei \texttt{/etc/shadow} stehen in verschlüsselter Form
-        gespeichert die Kennwörter aller Benutzerinnen auf dem System. Macht ein
-        \texttt{ls -l /etc/shadow} und schaut euch die Dateirechte an. Welche
-        Bits sind gesetzt?
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Geht in ein Verzeichnis, in dem eine \texttt{.cpp}-Datei liegt und
+              kompiliert sie. Macht ein \texttt{ls -l} und vergleicht die Rechte der
+              \texttt{.cpp}-Datei mit der kompilierten Datei.
+        \item In der Datei \texttt{/etc/shadow} stehen in verschlüsselter Form
+              gespeichert die Kennwörter aller Benutzerinnen auf dem System. Macht ein
+              \texttt{ls -l /etc/shadow} und schaut euch die Dateirechte an. Welche
+              Bits sind gesetzt?
+    \end{enumerate}
+\end{praxis}
 
-\textbf{Spiel:}
-\begin{enumerate}
-    \item Versucht, \texttt{/etc/shadow} in einem Editor zu öffnen.
-    \item Legt (z.B. mit dem Texteditor) eine Datei (Es geht nicht um
-        Kompilierung, also muss das keine \texttt{.cpp}-Datei sein. Gebt der
-        Datei am Besten die Erweiterung \texttt{.txt}) in Eurem Homeverzeichnis
-        an und macht sie dann mit \texttt{chmod a+w} world-writable
-        (\texttt{a+w} heißt „füge das Recht Schreibbarkeit für alle Nutzerinnen
-        hinzu“).  Lasst eure Sitznachbarin die Datei an ihrem Rechner öffnen
-        (ihr könnt mittels \texttt{pwd} herausfinden, in welchem Ordner sie
-        suchen muss) und euch eine Nachricht hinein schreiben. Schaut nach
-        (indem ihr die Datei neu öffnet) ob ihr die Nachricht lesen könnt.
-\end{enumerate}
+\begin{spiel}
+    \begin{enumerate}
+        \item Versucht, \texttt{/etc/shadow} in einem Editor zu öffnen.
+        \item Legt (z.B. mit dem Texteditor) eine Datei (Es geht nicht um
+              Kompilierung, also muss das keine \texttt{.cpp}-Datei sein. Gebt der
+              Datei am Besten die Erweiterung \texttt{.txt}) in Eurem Homeverzeichnis
+              an und macht sie dann mit \texttt{chmod a+w} world-writable
+              (\texttt{a+w} heißt „füge das Recht Schreibbarkeit für alle Nutzerinnen
+              hinzu“).  Lasst eure Sitznachbarin die Datei an ihrem Rechner öffnen
+              (ihr könnt mittels \texttt{pwd} herausfinden, in welchem Ordner sie
+              suchen muss) und euch eine Nachricht hinein schreiben. Schaut nach
+              (indem ihr die Datei neu öffnet) ob ihr die Nachricht lesen könnt.
+    \end{enumerate}
+\end{spiel}

--- a/basics/schleifen.tex
+++ b/basics/schleifen.tex
@@ -28,32 +28,32 @@ ist der Teiler, den wir gerade testen wollen und \texttt{hat\_teiler} gibt
 an, ob wir schon einen Teiler gefunden haben):
 
 \begin{center}
-    \begin{tikzpicture}[auto, node distance=3cm,>=latex']
-        \tikzstyle{block} = [draw, fill=blue!20, rectangle, minimum height=3em, minimum width=6em]
-        \tikzstyle{border} = [very thick, dashed, red]
+      \begin{tikzpicture}[auto, node distance=3cm,>=latex']
+            \tikzstyle{block} = [draw, fill=blue!20, rectangle, minimum height=3em, minimum width=6em]
+            \tikzstyle{border} = [very thick, dashed, red]
 
-        \node [block, align=center] (start) {$i = 2$ \\ \texttt{hat\_teiler} $=$ \texttt{false}};
-        \node [block, right of=start, node distance=4cm] (cond) {$i < n$?};
-        \node [block, right of=cond, node distance=3.5cm] (if) {$i\mid n$?};
-        \node [block, right of=if, node distance=4cm] (teiler) {\texttt{hat\_teiler} $\leftarrow$ \texttt{true}};
-        \node [block, above of=if, node distance=2cm] (incr) {$i \leftarrow i+1$};
-        \node [block, below of=cond, node distance=3cm] (prim?) {\texttt{hat\_teiler}?};
-        \node [block, below of=teiler, node distance=3cm] (yipp) {$n$ Primzahl};
-        \node [block, below of=yipp, node distance=1.5cm] (nope) {$n$ keine Primzahl};
+            \node [block, align=center] (start) {$i = 2$ \\ \texttt{hat\_teiler} $=$ \texttt{false}};
+            \node [block, right of=start, node distance=4cm] (cond) {$i < n$?};
+            \node [block, right of=cond, node distance=3.5cm] (if) {$i\mid n$?};
+            \node [block, right of=if, node distance=4cm] (teiler) {\texttt{hat\_teiler} $\leftarrow$ \texttt{true}};
+            \node [block, above of=if, node distance=2cm] (incr) {$i \leftarrow i+1$};
+            \node [block, below of=cond, node distance=3cm] (prim?) {\texttt{hat\_teiler}?};
+            \node [block, below of=teiler, node distance=3cm] (yipp) {$n$ Primzahl};
+            \node [block, below of=yipp, node distance=1.5cm] (nope) {$n$ keine Primzahl};
 
-        \draw [border] ($(cond) + (-1.5, 0)$) |- ($(if) + (0, -1)$) -| ($(teiler) + (2, 0)$) |- ($(incr) + (0, 1)$) -| cycle;
-        \node [border] at ($(cond) + (-.8, 3.3)$) {Schleife};
+            \draw [border] ($(cond) + (-1.5, 0)$) |- ($(if) + (0, -1)$) -| ($(teiler) + (2, 0)$) |- ($(incr) + (0, 1)$) -| cycle;
+            \node [border] at ($(cond) + (-.8, 3.3)$) {Schleife};
 
-        \draw [->] (start) -- node {} (cond);
-        \draw [->] (cond) -- node {ja} (if);
-        \draw [->] (cond) -- node [near end] {nein} (prim?);
-        \draw [->] (prim?) -- node {nein} (yipp);
-        \draw [->] (if) -- node {ja} (teiler);
-        \draw [->] (if) -- node {nein} (incr);
-        \draw [->] (incr) -| node {} (cond);
-        \draw [->] (teiler) |- (incr);
-        \draw [->] (prim?) |- node [near end] {ja} (nope);
-    \end{tikzpicture}
+            \draw [->] (start) -- node {} (cond);
+            \draw [->] (cond) -- node {ja} (if);
+            \draw [->] (cond) -- node [near end] {nein} (prim?);
+            \draw [->] (prim?) -- node {nein} (yipp);
+            \draw [->] (if) -- node {ja} (teiler);
+            \draw [->] (if) -- node {nein} (incr);
+            \draw [->] (incr) -| node {} (cond);
+            \draw [->] (teiler) |- (incr);
+            \draw [->] (prim?) |- node [near end] {ja} (nope);
+      \end{tikzpicture}
 \end{center}
 Das Besondere an Schleifen ist, dass sie geschlossene Kreise zum
 Kontrollflussdiagramm hinzufügen. Das erlaubt es uns, die gleiche Anweisung
@@ -71,29 +71,31 @@ kennengelernt habt, um \emph{Turing-vollständig} programmieren zu können, d.h.
 ihr könnt alleine mit den Mitteln, die ihr bisher kennen gelernt habt,
 \emph{jede} mögliche Berechnung anstellen!
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Versucht, die Arbeitsweise eines debuggers zu simulieren. Geht selbst
-          den Quellcode Zeile für Zeile durch, überlegt euch, was die Zeile tut
-          und welchen Inhalt die Variablen haben. Überlegt euch dann, wohin der
-          Computer (bei Kontrollflussstrukturen) als nächstes springen würde.
-          Wenn ihr nicht weiter wisst, kompiliert das Programm für den debugger,
-          startet es im debugger und geht es durch.
-    \item Warum funktioniert das Programm für den Fall $n = 2$?
-    \item Schreibt selbst ein Programm, welches eine Zahl von der Nutzerin
-          entgegennimmt und dann alle Zahlen bis zu dieser Zahl ausgibt.
-    \item Modifiziert euer Programm, sodass es von dieser Zahl bis zu 0
-          hinunterzählt.
-\end{enumerate}
+\begin{praxis}
+      \begin{enumerate}
+            \item Versucht, die Arbeitsweise eines debuggers zu simulieren. Geht selbst
+                  den Quellcode Zeile für Zeile durch, überlegt euch, was die Zeile tut
+                  und welchen Inhalt die Variablen haben. Überlegt euch dann, wohin der
+                  Computer (bei Kontrollflussstrukturen) als nächstes springen würde.
+                  Wenn ihr nicht weiter wisst, kompiliert das Programm für den debugger,
+                  startet es im debugger und geht es durch.
+            \item Warum funktioniert das Programm für den Fall $n = 2$?
+            \item Schreibt selbst ein Programm, welches eine Zahl von der Nutzerin
+                  entgegennimmt und dann alle Zahlen bis zu dieser Zahl ausgibt.
+            \item Modifiziert euer Programm, sodass es von dieser Zahl bis zu 0
+                  hinunterzählt.
+      \end{enumerate}
+\end{praxis}
 
-\textbf{Spiel:}
-\begin{enumerate}
-    \item Das Programm funktioniert noch nicht korrekt, wenn man 1 eingibt
-          (denn 1 ist keine Primzahl). Modifiziert es, sodass es auch für 1
-          funktioniert.
-    \item Kompiliert \texttt{whiletrue.cpp} und führt es aus. Was beobachtet
-          ihr? Warum? (Ihr könnt das Programm abbrechen, indem ihr
-          \texttt{Strg+C} drückt)
-\end{enumerate}
+\begin{spiel}
+      \begin{enumerate}
+            \item Das Programm funktioniert noch nicht korrekt, wenn man 1 eingibt
+                  (denn 1 ist keine Primzahl). Modifiziert es, sodass es auch für 1
+                  funktioniert.
+            \item Kompiliert \texttt{whiletrue.cpp} und führt es aus. Was beobachtet
+                  ihr? Warum? (Ihr könnt das Programm abbrechen, indem ihr
+                  \texttt{Strg+C} drückt)
+      \end{enumerate}
 
-\inputcpp{whiletrue.cpp}
+      \inputcpp{whiletrue.cpp}
+\end{spiel}

--- a/basics/stdbib.tex
+++ b/basics/stdbib.tex
@@ -28,41 +28,41 @@ Namespace \texttt{std}“.
 
 \inputcpp{namespaces.cpp}
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Was gibt dieses Programm aus, wenn man es kompiliert und ausführt?
-        Überlegt es euch zuerst selbst, dann probiert es aus.
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Was gibt dieses Programm aus, wenn man es kompiliert und ausführt?
+              Überlegt es euch zuerst selbst, dann probiert es aus.
+    \end{enumerate}
 
-Wenn ihr wissen wollt, was die Standardbibliothek alles so für euch bereit
-stellt, könnt ihr euch in der Referenz der Standardbibliothek unter
+    Wenn ihr wissen wollt, was die Standardbibliothek alles so für euch bereit
+    stellt, könnt ihr euch in der Referenz der Standardbibliothek unter
 
-\url{http://www.cplusplus.com/reference/}
+    \url{http://www.cplusplus.com/reference/}
 
-umschauen. Es ist nicht ganz einfach, zu wissen, wo man dort findet, was man
-sucht, in dem Fall kann Google ein im Regelfall ganz gut helfen. Wenn man
-einmal weiß, \emph{was} man sucht, findet man in der Referenz vor allem,
-\emph{wie} man es benutzt.
+    umschauen. Es ist nicht ganz einfach, zu wissen, wo man dort findet, was man
+    sucht, in dem Fall kann Google ein im Regelfall ganz gut helfen. Wenn man
+    einmal weiß, \emph{was} man sucht, findet man in der Referenz vor allem,
+    \emph{wie} man es benutzt.
 
-Die Standardbibliothek ist aufgeteilt auf so genannt \emph{Headerdateien}, die
-wir mittels \texttt{\#include} benutzen können. Diese Header sind, worunter ihr
-zuerst wählt, wenn ihr auf obige url geht. Jeder Header definiert dann eine
-Menge an Funktionen, Typen und Klassen (was genau eine Klasse ist, lernt ihr
-spätestens in der Vorlesung).
+    Die Standardbibliothek ist aufgeteilt auf so genannt \emph{Headerdateien}, die
+    wir mittels \texttt{\#include} benutzen können. Diese Header sind, worunter ihr
+    zuerst wählt, wenn ihr auf obige url geht. Jeder Header definiert dann eine
+    Menge an Funktionen, Typen und Klassen (was genau eine Klasse ist, lernt ihr
+    spätestens in der Vorlesung).
 
-\textbf{Praxis:}
-\begin{enumerate}
-	\item Findet in der \Cpp-Referenz eine Funktion, um die aktuelle Zeit
-		auszugeben. Schreibt ein Programm, welches die Aktuelle Zeit ausgibt
-		(es reicht, einen so genannten \emph{Unix timestamp}\footnote{Der
-		Unix-Timestamp ist eine einzelne Zahl, die alle Sekunden seit dem
-	1.1.1970 anzeigt und die also jede Sekunde eins größer wird} auszugeben).
-	Ihr könnt die Ausgabe eures Programms mit der Ausgabe von \texttt{date
-		+\%s} vergleichen, um es zu testen.
-    \item Mit der Funktion \texttt{rand()} könnt ihr Zufallszahlen generieren
-        (ihr braucht dazu den Header \texttt{<cstdlib>}). Schreibt ein
-        Programm, welches vom Benutzer eine Zahl entgegennimmt und diese Anzahl
-        Zufallszahlen ausgibt. Führt das Programm mehrfach aus. Was fällt auf?
-    \item Konsultiert die \Cpp-Referenz, um heraus zu finden, wo das Problem
-        liegt. Könnt ihr es beheben?
-\end{enumerate}
+    \begin{enumerate}[resume]
+        \item Findet in der \Cpp-Referenz eine Funktion, um die aktuelle Zeit
+              auszugeben. Schreibt ein Programm, welches die Aktuelle Zeit ausgibt
+              (es reicht, einen so genannten \emph{Unix timestamp}\footnote{Der
+                  Unix-Timestamp ist eine einzelne Zahl, die alle Sekunden seit dem
+                  1.1.1970 anzeigt und die also jede Sekunde eins größer wird} auszugeben).
+              Ihr könnt die Ausgabe eures Programms mit der Ausgabe von \texttt{date
+                  +\%s} vergleichen, um es zu testen.
+        \item Mit der Funktion \texttt{rand()} könnt ihr Zufallszahlen generieren
+              (ihr braucht dazu den Header \texttt{<cstdlib>}). Schreibt ein
+              Programm, welches vom Benutzer eine Zahl entgegennimmt und diese Anzahl
+              Zufallszahlen ausgibt. Führt das Programm mehrfach aus. Was fällt auf?
+        \item Konsultiert die \Cpp-Referenz, um heraus zu finden, wo das Problem
+              liegt. Könnt ihr es beheben?
+    \end{enumerate}
+\end{praxis}

--- a/basics/style.tex
+++ b/basics/style.tex
@@ -11,63 +11,63 @@ tut, wie er strukturiert ist, welche Variable was bedeutet. Um dies zu
 unterstützen, gibt es mehrere Dinge, auf die man achten kann.
 
 \begin{description}
-      \item[Einrückung]
-            Wie euch vermutlich aufgefallen ist, sind an verschiedenen Stellen im
-            Code einzelne Zeilen ein wenig eingerückt. Dies ist vermutlich das
-            wichtigste Werkzeug, welches zur Verfügung steht, um die Lesbarkeit von
-            Code zu unterstützen (auch, wenn es nicht nötig ist, um formal korrekte
-            Programme zu schreiben). Die einzelnen Einheiten des Kontrollflusss
-            werden dadurch visuell voneinander abgegrenzt, was es einfacher macht,
-            den Programmverlauf zu verfolgen.
+    \item[Einrückung]
+          Wie euch vermutlich aufgefallen ist, sind an verschiedenen Stellen im
+          Code einzelne Zeilen ein wenig eingerückt. Dies ist vermutlich das
+          wichtigste Werkzeug, welches zur Verfügung steht, um die Lesbarkeit von
+          Code zu unterstützen (auch, wenn es nicht nötig ist, um formal korrekte
+          Programme zu schreiben). Die einzelnen Einheiten des Kontrollflusss
+          werden dadurch visuell voneinander abgegrenzt, was es einfacher macht,
+          den Programmverlauf zu verfolgen.
 
-            Wie genau eingerückt werden sollte, darüber scheiden sich die Geister.
-            Man kann mit mehreren Leerzeichen oder durch Tabulatoren einrücken.
-            Empfehlenswert ist auf jeden Fall, mehrere gleichförmige „Ebenen“ zu
-            haben (z.B. 4, 8, 12, \dots\ Leerzeichen zu Beginn der Zeile). Eine
-            Faustregel für gut lesbare Einrückung ist, immer wenn man eine
-            geschweifte Klammer öffnet, eine Ebene tiefer einzurücken und immer,
-            wenn man eine geschweifte Klammer schließt, wieder eine Ebene zurück zu
-            nehmen.
-      \item[Klammern]
-            Aus der Schule kennt ihr das Prinzip „Punkt- vor Strichrechnung“. Dies
-            ist eine Regel, die so genannte \emph{Präzedenz} ausdrückt, also die
-            Reihenfolge, in der Operatoren ausgewertet werden. Punkt vor Strich ist
-            allerdings nicht aussreichend, um vollständig zu beschreiben, wie sich
-            Operatoren in Gruppen verhalten. Schaut euch z.B. den Ausdruck
-            \texttt{3 * 2 / 3} an. Da der Computer Ganzzahldivision benutzt, kommen
-            hier unterschiedliche Ergebniss raus, je nachdem, ob zunächst das
-            \texttt{*} oder das \texttt{/} ausgewertet wird. Im ersten Fall
-            erhalten wir \texttt{6 / 3 == 2}, wie wir erwarten würden. Im zweiten
-            Fall wird aber abgerundet, sodass wir \texttt{3 * 0 == 0} erhalten.
+          Wie genau eingerückt werden sollte, darüber scheiden sich die Geister.
+          Man kann mit mehreren Leerzeichen oder durch Tabulatoren einrücken.
+          Empfehlenswert ist auf jeden Fall, mehrere gleichförmige „Ebenen“ zu
+          haben (z.B. 4, 8, 12, \dots\ Leerzeichen zu Beginn der Zeile). Eine
+          Faustregel für gut lesbare Einrückung ist, immer wenn man eine
+          geschweifte Klammer öffnet, eine Ebene tiefer einzurücken und immer,
+          wenn man eine geschweifte Klammer schließt, wieder eine Ebene zurück zu
+          nehmen.
+    \item[Klammern]
+          Aus der Schule kennt ihr das Prinzip „Punkt- vor Strichrechnung“. Dies
+          ist eine Regel, die so genannte \emph{Präzedenz} ausdrückt, also die
+          Reihenfolge, in der Operatoren ausgewertet werden. Punkt vor Strich ist
+          allerdings nicht aussreichend, um vollständig zu beschreiben, wie sich
+          Operatoren in Gruppen verhalten. Schaut euch z.B. den Ausdruck
+          \texttt{3 * 2 / 3} an. Da der Computer Ganzzahldivision benutzt, kommen
+          hier unterschiedliche Ergebniss raus, je nachdem, ob zunächst das
+          \texttt{*} oder das \texttt{/} ausgewertet wird. Im ersten Fall
+          erhalten wir \texttt{6 / 3 == 2}, wie wir erwarten würden. Im zweiten
+          Fall wird aber abgerundet, sodass wir \texttt{3 * 0 == 0} erhalten.
 
-            Um solche und ähnliche Uneindeutigkeiten zu vermeiden, bietet es sich
-            an, Klammerung zu verwenden. Selbst wenn wir im obigen Fall
-            \emph{wissen} in welcher Reihenfolge die Operatoren ausgewertet werden,
-            jemand der unseren Code liest, weiß das vielleicht nicht. Einfach von
-            vornherein die gewollte Reihenfolge der Auswertung zu klammern,
-            verhindert Verwirrung bei uns über das Verhalten des Computers, als
-            auch bei Menschen, die später wissen wollen, was wir meinten.
+          Um solche und ähnliche Uneindeutigkeiten zu vermeiden, bietet es sich
+          an, Klammerung zu verwenden. Selbst wenn wir im obigen Fall
+          \emph{wissen} in welcher Reihenfolge die Operatoren ausgewertet werden,
+          jemand der unseren Code liest, weiß das vielleicht nicht. Einfach von
+          vornherein die gewollte Reihenfolge der Auswertung zu klammern,
+          verhindert Verwirrung bei uns über das Verhalten des Computers, als
+          auch bei Menschen, die später wissen wollen, was wir meinten.
 
-            Ihr könnt übrigens nicht nur einzeilige Kommentare erstellen, die mit \cppinline{//} beginnen, sondern auch mehrzeilige, und zwar so: \cppinline{/* Dies ist ein ganz langer mehrzeiliger Kommentar.  */} . Alles zwischen den Slashes und Sternchen ist dann ein Kommentar und wird vom Computer ignoriert. Dies könnt ihr als kleinen Trick verwenden, um euren Code zu debuggen, ohne ständig alles neu zu schreiben. Ihr könnt stattdessen einfach den nicht benötigten Code auskommentieren und wenn ihr ihn wieder verwenden wollt, die Kommentarzeichen am Anfang und Ende wieder entfernen.
-      \item[Kommentare]
-            Wir haben schon in mehreren Quellcodedateien Kommentare verwendet, um
-            einzelne Dinge zu erklären. Insgesamt bietet es sich an, dies selbst
-            ebenfalls zu tun, um den Programmfluss der Leserin von Quellcode klar zu
-            machen. Das heißt nicht, dass man jede Anweisung noch einmal mit einem
-            Kommantar versehen sollte, der sie ausführlich erklärt, aber an
-            wichtigen Punkten können einem kurze Kommentare das Leben enorm
-            vereinfachen. Und ihr dürft nicht vergessen, dass ihr euch vielleicht
-            selbst in ein oder zwei Jahren noch einmal euren eigenen Quellcode
-            anschauen müsst und ihr werdet wirklich überrascht sein, wie wenig ihr
-            von dem Zeug, welches ihr selbst geschrieben habt, verstehen werdet.
-      \item [Benennungen]
-            Wenn ihr eure Variablen -- und später auch eure Funktionen und Klassen -- präzise benennt, dann vereinfacht ihr das Lesen eures Codes extrem. Durch Bezeichnungen, die für sich sprechen, könnt ihr euch außerdem Kommentare etwas ersparen, weil die Variablennamen dann schon viel erklären. Es ist zum Beispiel ungeschickt, seine Variablen wie in der Mathematik üblich einfach nur mit einzelnen Buchstaben zu benennen, statt \cppinline{int a = 42;} sollte man lieber \cppinline{int alter = 42;} verwenden, da die Leserin direkt weiß, dass in dieser Variablen das Alter gespeichert wird. Zu dieser coding style Richtlinie gibt es jedoch auch eine Ausnahme: Bei Zählervariablen, die einfach nur die Anzahl der Schleifeniterationen hochzählen, verwendet man meist einzelne Buchstaben, wie \cppinline{i} oder \cppinline{n}. Das ist schön kurz und praktisch, jedoch muss man etwas aufpassen, denn man kann schnell mit diesen Indices durcheinander kommen -- genau so wie in der Mathematik.
-      \item[Leerzeichen und -zeilen]
-            Weniger wichtig als die ersten vier Punkte können trotzdem gezielte
-            Leerzeichen (z.B. zwischen Operatoren und Operanden in arithmetischen
-            Ausdrücken) die Lesbarkeit enorm erhöhen. Gerade in arithmetischen
-            Ausdrücken ist es eine gute Angewohnheit.
-            Ebenso sind Leerzeilen zwischen logischen Abschnitten sehr hilfreich. Zu Beginn eines Abschnittes kann man dann noch einen kurzen Kommentar hinzufügen, was in dem Abschnitt passiert und schon fällt das Lesen des Codes deutlich leichter.
+          Ihr könnt übrigens nicht nur einzeilige Kommentare erstellen, die mit \cppinline{//} beginnen, sondern auch mehrzeilige, und zwar so: \cppinline{/* Dies ist ein ganz langer mehrzeiliger Kommentar.  */} . Alles zwischen den Slashes und Sternchen ist dann ein Kommentar und wird vom Computer ignoriert. Dies könnt ihr als kleinen Trick verwenden, um euren Code zu debuggen, ohne ständig alles neu zu schreiben. Ihr könnt stattdessen einfach den nicht benötigten Code auskommentieren und wenn ihr ihn wieder verwenden wollt, die Kommentarzeichen am Anfang und Ende wieder entfernen.
+    \item[Kommentare]
+          Wir haben schon in mehreren Quellcodedateien Kommentare verwendet, um
+          einzelne Dinge zu erklären. Insgesamt bietet es sich an, dies selbst
+          ebenfalls zu tun, um den Programmfluss der Leserin von Quellcode klar zu
+          machen. Das heißt nicht, dass man jede Anweisung noch einmal mit einem
+          Kommantar versehen sollte, der sie ausführlich erklärt, aber an
+          wichtigen Punkten können einem kurze Kommentare das Leben enorm
+          vereinfachen. Und ihr dürft nicht vergessen, dass ihr euch vielleicht
+          selbst in ein oder zwei Jahren noch einmal euren eigenen Quellcode
+          anschauen müsst und ihr werdet wirklich überrascht sein, wie wenig ihr
+          von dem Zeug, welches ihr selbst geschrieben habt, verstehen werdet.
+    \item [Benennungen]
+          Wenn ihr eure Variablen -- und später auch eure Funktionen und Klassen -- präzise benennt, dann vereinfacht ihr das Lesen eures Codes extrem. Durch Bezeichnungen, die für sich sprechen, könnt ihr euch außerdem Kommentare etwas ersparen, weil die Variablennamen dann schon viel erklären. Es ist zum Beispiel ungeschickt, seine Variablen wie in der Mathematik üblich einfach nur mit einzelnen Buchstaben zu benennen, statt \cppinline{int a = 42;} sollte man lieber \cppinline{int alter = 42;} verwenden, da die Leserin direkt weiß, dass in dieser Variablen das Alter gespeichert wird. Zu dieser coding style Richtlinie gibt es jedoch auch eine Ausnahme: Bei Zählervariablen, die einfach nur die Anzahl der Schleifeniterationen hochzählen, verwendet man meist einzelne Buchstaben, wie \cppinline{i} oder \cppinline{n}. Das ist schön kurz und praktisch, jedoch muss man etwas aufpassen, denn man kann schnell mit diesen Indices durcheinander kommen -- genau so wie in der Mathematik.
+    \item[Leerzeichen und -zeilen]
+          Weniger wichtig als die ersten vier Punkte können trotzdem gezielte
+          Leerzeichen (z.B. zwischen Operatoren und Operanden in arithmetischen
+          Ausdrücken) die Lesbarkeit enorm erhöhen. Gerade in arithmetischen
+          Ausdrücken ist es eine gute Angewohnheit.
+          Ebenso sind Leerzeilen zwischen logischen Abschnitten sehr hilfreich. Zu Beginn eines Abschnittes kann man dann noch einen kurzen Kommentar hinzufügen, was in dem Abschnitt passiert und schon fällt das Lesen des Codes deutlich leichter.
 \end{description}
 
 Es gibt sicher noch viele Regeln, über die ihr im Laufe eures Lebens stolpern
@@ -78,24 +78,27 @@ ob es nun vergessene Klammern, Semikolons oder versteckte Fehler in der
 Operatorpräzedenz sind, ein sauberer Stil kann euch bei allen enorm helfen, sie
 aufzuspüren. Auch wenn es coding style Richtlinien für verschiedene Programmiersprachen gibt, die größtenteils relativ ähnlich sind, gewöhnt man sich meist einen eigenen Stil mit der Zeit an. Es ist allerdings wichtig, früh auf guten Stil zu achten, denn wenn man erst einmal damit anfängt, unübersichtlichen Code zu schreiben, gewöhnt man sich diese Unart an und das will schließlich niemand.
 
-\textbf{Praxis:}
-\begin{enumerate}
-      \item Eine weit verbreitete einfache Aufgabe, die in Bewerbungsgesprächen
-            auf Stellen als Programmiererin häufig gestellt wird, ist
-            \emph{FizzBuzz}. In \texttt{fizzbuzz.cpp} ist eine möglich Lösung für
-            diese Aufgabe gegeben. Könnt ihr (nur mittels des Quellcodes) sagen,
-            was das Programm tut?
-      \item Nutzt die oben gegebenen Faustregeln, um den Quellcode lesbarer zu
-            machen. Ihr müsst nicht alles bis aufs Wort befolgen, macht einfach so
-            lange weiter, bis ihr findet, man kann hinreichend schnell verstehen,
-            was hier passieren soll.
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Eine weit verbreitete einfache Aufgabe, die in Bewerbungsgesprächen
+              auf Stellen als Programmiererin häufig gestellt wird, ist
+              \emph{FizzBuzz}. In \texttt{fizzbuzz.cpp} ist eine möglich Lösung für
+              diese Aufgabe gegeben. Könnt ihr (nur mittels des Quellcodes) sagen,
+              was das Programm tut?
+        \item Nutzt die oben gegebenen Faustregeln, um den Quellcode lesbarer zu
+              machen. Ihr müsst nicht alles bis aufs Wort befolgen, macht einfach so
+              lange weiter, bis ihr findet, man kann hinreichend schnell verstehen,
+              was hier passieren soll.
+    \end{enumerate}
 
-\inputcpp{fizzbuzz.cpp}
+    \inputcpp{fizzbuzz.cpp}
 
-\textbf{Spiel:}
-\begin{enumerate}
-      \item Entfernt in eurem veränderten Quellcode eine geschweifte Klammer
-            eurer Wahl. Lasst eure Sitznachbarin über den Quellcode schauen und die
-            fehlende Klammer finden.
-\end{enumerate}
+\end{praxis}
+
+\begin{spiel}
+    \begin{enumerate}
+        \item Entfernt in eurem veränderten Quellcode eine geschweifte Klammer
+              eurer Wahl. Lasst eure Sitznachbarin über den Quellcode schauen und die
+              fehlende Klammer finden.
+    \end{enumerate}
+\end{spiel}

--- a/basics/tictactoe1.tex
+++ b/basics/tictactoe1.tex
@@ -26,23 +26,23 @@ voranstellen. In \texttt{tictactoe.cpp} ist dies am Beispiel von
 \texttt{tictactoe.o} definiert euch insgesamt folgende Funktionen:
 \begin{description}
 	\item[frage\_feld\_nummer]
-		Nimmt einen Vektor mit 9 \texttt{int}s entgegen und gibt einen \texttt{int} zurück.
+	      Nimmt einen Vektor mit 9 \texttt{int}s entgegen und gibt einen \texttt{int} zurück.
 
-		Gibt auf der Konsole eine Frage nach der Feldnummer aus (durchnummeriert von 0 bis 8), liest eine Feldnummer von der Nutzerin ein und gibt diese zurück.
-		Die Funktion stellt sicher, dass die Feldnummer zwischen 0 und 8 liegt und dass das Feld noch nicht besetzt ist (sonst wird noch einmal nachgefragt).
+	      Gibt auf der Konsole eine Frage nach der Feldnummer aus (durchnummeriert von 0 bis 8), liest eine Feldnummer von der Nutzerin ein und gibt diese zurück.
+	      Die Funktion stellt sicher, dass die Feldnummer zwischen 0 und 8 liegt und dass das Feld noch nicht besetzt ist (sonst wird noch einmal nachgefragt).
 	\item[gebe\_feld\_aus]
-		Nimmt einen Vektor mit 9 \texttt{int}s entgegen und hat als Rückgabetyp \texttt{void} (was für „keine Rückgabe“ steht).
+	      Nimmt einen Vektor mit 9 \texttt{int}s entgegen und hat als Rückgabetyp \texttt{void} (was für „keine Rückgabe“ steht).
 
-		Gibt das gegebene Feld auf der Konsole aus. Dabei werden die 9 Felder von oben links nach unten rechts von 0 beginnend durchnummeriert.
-		Der 9-elementige Vektor stellt also das Feld dar.
-		Eine 0 in einem Vektorelement bedeutet, dass das Feld leer ist, eine 1 bedeutet, dass sich dort ein \textbf{X} befindet und eine 2 bedeutet, dass sich ein \textbf{O} dort befindet.
-		Andere Werte werden mit einem \textbf{?} dargestellt.
+	      Gibt das gegebene Feld auf der Konsole aus. Dabei werden die 9 Felder von oben links nach unten rechts von 0 beginnend durchnummeriert.
+	      Der 9-elementige Vektor stellt also das Feld dar.
+	      Eine 0 in einem Vektorelement bedeutet, dass das Feld leer ist, eine 1 bedeutet, dass sich dort ein \textbf{X} befindet und eine 2 bedeutet, dass sich ein \textbf{O} dort befindet.
+	      Andere Werte werden mit einem \textbf{?} dargestellt.
 	\item[gewinnerin]
-		Nimmt einen Vektor mit 9 \texttt{int}s entgegen und hat als Rückgabetyp \texttt{int}.
+	      Nimmt einen Vektor mit 9 \texttt{int}s entgegen und hat als Rückgabetyp \texttt{int}.
 
-		Prüft, ob in diesem Zustand des Feldes bereits eine der Spielerinnen gewonnen hat.
-		Die Funktion gibt 0 zurück, wenn noch niemand gewonnen hat, 1, wenn die Spielerin \textbf{X} gewonnen hat und 2, wenn die Spielerin \textbf{O} gewonnen hat.
-		Sollte das Spiel unentschieden ausgegangen sein, wird eine 3 zurück gegeben.
+	      Prüft, ob in diesem Zustand des Feldes bereits eine der Spielerinnen gewonnen hat.
+	      Die Funktion gibt 0 zurück, wenn noch niemand gewonnen hat, 1, wenn die Spielerin \textbf{X} gewonnen hat und 2, wenn die Spielerin \textbf{O} gewonnen hat.
+	      Sollte das Spiel unentschieden ausgegangen sein, wird eine 3 zurück gegeben.
 \end{description}
 
 Der zweite Teil, den ihr zur Benutzung der Funktionen braucht ist das Linken (was genau das bedeutet, wird später noch erklärt).
@@ -50,33 +50,35 @@ Dies ist fürs Erste sehr einfach: Ihr gebt einfach dem \texttt{g++} Befehl zus�
 
 \inputcpp{tictactoe.cpp}
 
-\textbf{Praxis:}
-\begin{enumerate}
-	\item
-		Ergänzt \texttt{tictactoe.cpp} um Deklarationen für die anderen beschriebenen Funktionen aus \texttt{tictactoe.o}.
-		Einen Vektor als Parameter könnt ihr in genau der gleichen Notation angeben, wie ihr es euch in einer Funktion als Variable definieren würdet.
-	\item
-		Das Grundgerüst eines Spiels ist die \emph{input-update-display}-loop.
-    Dies ist eine Endlosschleife, in der zunächst der \emph{input} der Spielerin abgefragt wird.
-		Anschließend wird der interne Spielzustand aktualisiert (\emph{update}).
-		Zuletzt wird der neue Spielzustand angezeigt (\emph{display}).
-		Der anfängliche Spielzustand wird vor dieser loop hergestellt (\emph{setup}).
+\begin{praxis}
+	\begin{enumerate}
+		\item
+		      Ergänzt \texttt{tictactoe.cpp} um Deklarationen für die anderen beschriebenen Funktionen aus \texttt{tictactoe.o}.
+		      Einen Vektor als Parameter könnt ihr in genau der gleichen Notation angeben, wie ihr es euch in einer Funktion als Variable definieren würdet.
+		\item
+		      Das Grundgerüst eines Spiels ist die \emph{input-update-display}-loop.
+		      Dies ist eine Endlosschleife, in der zunächst der \emph{input} der Spielerin abgefragt wird.
+		      Anschließend wird der interne Spielzustand aktualisiert (\emph{update}).
+		      Zuletzt wird der neue Spielzustand angezeigt (\emph{display}).
+		      Der anfängliche Spielzustand wird vor dieser loop hergestellt (\emph{setup}).
 
-		\texttt{tictactoe.cpp} zeigt dieses Grundgerüst.
-		Ergänzt den input- und den display-Teil mithilfe der gegebenen Funktionen.
-		Ergänzt auch den setup-Teil; ihr braucht für den Spielzustand einerseits den Vektor, welcher das Spielfeld fassen soll, andererseits eine Variable für die Spielerin, die gerade am Zug ist und eine Variable, die das im aktuellen Zug eingegebene Feld speichert.
-		Vergesst auch nicht, dass ihr das Feld zu Beginn 9 0en enhalten muss.
-	\item
-		Nun müssen wir noch den Update-Teil ergänzen.
-		Hier solltet ihr in das von der aktuellen Spielerin gewählte Feld mit deren Nummer füllen, testen, ob jemand gewonnen hat und wenn ja, die Siegerin ausgeben und euer Programm beenden (denkt daran, dass das Spiel auch unentschieden ausgehen kann).
-		Sonst sollte die aktuelle Spielerin gewechselt werden.
-\end{enumerate}
+		      \texttt{tictactoe.cpp} zeigt dieses Grundgerüst.
+		      Ergänzt den input- und den display-Teil mithilfe der gegebenen Funktionen.
+		      Ergänzt auch den setup-Teil; ihr braucht für den Spielzustand einerseits den Vektor, welcher das Spielfeld fassen soll, andererseits eine Variable für die Spielerin, die gerade am Zug ist und eine Variable, die das im aktuellen Zug eingegebene Feld speichert.
+		      Vergesst auch nicht, dass ihr das Feld zu Beginn 9 0en enhalten muss.
+		\item
+		      Nun müssen wir noch den Update-Teil ergänzen.
+		      Hier solltet ihr in das von der aktuellen Spielerin gewählte Feld mit deren Nummer füllen, testen, ob jemand gewonnen hat und wenn ja, die Siegerin ausgeben und euer Programm beenden (denkt daran, dass das Spiel auch unentschieden ausgehen kann).
+		      Sonst sollte die aktuelle Spielerin gewechselt werden.
+	\end{enumerate}
+\end{praxis}
 
-\textbf{Spiel:}
-\begin{enumerate}
-	\item
-		Okay, das ist nun wirklich nicht schwierig zu erraten oder?
-		Wenn ihr dem obigen Rezept gefolgt seid, habt ihr jetzt ein funktionierendes Tic-Tac-Toe Spiel.
-		Und ihr habt eine Sitznachbarin.
-		Zählt eins und eins zusammen.
-\end{enumerate}
+\begin{spiel}
+	\begin{enumerate}
+		\item
+		      Okay, das ist nun wirklich nicht schwierig zu erraten oder?
+		      Wenn ihr dem obigen Rezept gefolgt seid, habt ihr jetzt ein funktionierendes Tic-Tac-Toe Spiel.
+		      Und ihr habt eine Sitznachbarin.
+		      Zählt eins und eins zusammen.
+	\end{enumerate}
+\end{spiel}

--- a/basics/tictactoe2.tex
+++ b/basics/tictactoe2.tex
@@ -27,23 +27,24 @@ doch selbst aus, in welcher Reihenfolge ihr sie bearbeiten wollt, sie ist
 ziemlich beliebig. Fangt am Besten mit dem Teil an, der euch am leichtesten
 erscheint.
 
-\textbf{Praxis:}
-\begin{itemize}
-    \item Implementiert \texttt{frage\_feld\_nummer} nach. Ihr solltet darauf
-        achten, dass ihr in dieser Funktion auch testen müsst, ob ein gültiges
-        Feld eingegeben wurde und ob das angegebene Feld leer ist.
-    \item Implementiert \texttt{gebe\_feld\_aus} nach. Ihr könnt euch selbst
-        aussuchen, wie ihr die Ausgabe gestalten wollt -- es muss nicht genauso
-        aussehen, wie unser Vorschlag. Die
-        Wikipedia\footnote{\url{http://en.wikipedia.org/wiki/Box-drawing_character}}
-        kann euch z.B. helfen, ein schöneres Feld auszugeben. Fangt am Besten
-        mit einer einfachen Ausgabe an und macht sie dann immer „fancier“.
-    \item Implementiert \texttt{gewinnerin} nach. Bedenkt, dass ihr alle
-        Möglichkeiten testet, auf die ein Gewinn möglich ist -- also 3
-        Möglichkeiten, eine Reihe zu bilden, 3 Möglichkeiten, eine Spalte zu
-        bilden und 2 Möglichkeiten für Diagonalen. Überlegt euch zunächst, wie
-        ihr zwischen Feldnummer (0-8) und Reihen- bzw. Spaltennummer hin- und
-        herrechnen könnt. Beachtet auch, dass es ein Unentschieden gibt, wenn
-        alle Felder belegt sind, aber keine von beiden Spielerinnen gewonnen
-        hat.
-\end{itemize}
+\begin{praxis}
+    \begin{itemize}
+        \item Implementiert \texttt{frage\_feld\_nummer} nach. Ihr solltet darauf
+              achten, dass ihr in dieser Funktion auch testen müsst, ob ein gültiges
+              Feld eingegeben wurde und ob das angegebene Feld leer ist.
+        \item Implementiert \texttt{gebe\_feld\_aus} nach. Ihr könnt euch selbst
+              aussuchen, wie ihr die Ausgabe gestalten wollt -- es muss nicht genauso
+              aussehen, wie unser Vorschlag. Die
+              Wikipedia\footnote{\url{http://en.wikipedia.org/wiki/Box-drawing_character}}
+              kann euch z.B. helfen, ein schöneres Feld auszugeben. Fangt am Besten
+              mit einer einfachen Ausgabe an und macht sie dann immer „fancier“.
+        \item Implementiert \texttt{gewinnerin} nach. Bedenkt, dass ihr alle
+              Möglichkeiten testet, auf die ein Gewinn möglich ist -- also 3
+              Möglichkeiten, eine Reihe zu bilden, 3 Möglichkeiten, eine Spalte zu
+              bilden und 2 Möglichkeiten für Diagonalen. Überlegt euch zunächst, wie
+              ihr zwischen Feldnummer (0-8) und Reihen- bzw. Spaltennummer hin- und
+              herrechnen könnt. Beachtet auch, dass es ein Unentschieden gibt, wenn
+              alle Felder belegt sind, aber keine von beiden Spielerinnen gewonnen
+              hat.
+    \end{itemize}
+\end{praxis}

--- a/basics/variablen.tex
+++ b/basics/variablen.tex
@@ -21,17 +21,19 @@ Dieser wird benötigt, damit der Computer weiß, um was für eine Art Wert es si
 Beispielsweise kann man zwei Zahlen miteinander multiplizieren, für Texte ergibt das allerdings keinen Sinn.
 In der Lektion Arithmetik lernen wir mehr über Zahlen und deren Eigenheiten.
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Was passiert, wenn ihr \cppinline{beschreibung} in Zeile 5 ein anderes Wort zuweist?
-    \item Definiert eine weitere Variable und schreibt einen weiteren Satz.
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Was passiert, wenn ihr \cppinline{beschreibung} in Zeile 5 ein anderes Wort zuweist?
+        \item Definiert eine weitere Variable und schreibt einen weiteren Satz.
+    \end{enumerate}
+\end{praxis}
 
-\textbf{Spiel:}
-\begin{enumerate}
-    \item Was passiert, wenn ihr euch im Namen einer Variable „vertippt“?
-    \item Definiert euch zwei \cppinline{std::string} Variablen, weist ihnen
-        irgendwelchen Text zu, versucht, sie zu addieren und das Ergebnis auszugeben.
-    \item Was passiert, wenn ihr eine \cppinline{std::string} Variable definiert,
-        ihr aber nichts zuweist und dann versucht, sie auszugeben?
-\end{enumerate}
+\begin{spiel}
+    \begin{enumerate}
+        \item Was passiert, wenn ihr euch im Namen einer Variable „vertippt“?
+        \item Definiert euch zwei \cppinline{std::string} Variablen, weist ihnen
+              irgendwelchen Text zu, versucht, sie zu addieren und das Ergebnis auszugeben.
+        \item Was passiert, wenn ihr eine \cppinline{std::string} Variable definiert,
+              ihr aber nichts zuweist und dann versucht, sie auszugeben?
+    \end{enumerate}
+\end{spiel}

--- a/basics/vektoren.tex
+++ b/basics/vektoren.tex
@@ -8,20 +8,20 @@ Die Elemente in einem Vektor sind durchnummeriert, man nennt die Nummer eines Ve
 Das erste Element hat den Index 0, das zweite den Index 1 und das 100te hat den Index 99 -- Vorsicht also, der höchste Index in einem Vektor mit 100 Elementen ist 99, nicht 100!
 Um einen Vektor zu definieren, schreibt ihr:
 \begin{center}
-\cppinline{std::vector<}\emph{Datentyp}\cppinline{> einvektor;}
+	\cppinline{std::vector<}\emph{Datentyp}\cppinline{> einvektor;}
 \end{center}
 um den Datentypen schreibt ihr also noch \cppinline{std::vector<}\dots\cppinline{>}.
 Um ein Element am Ende einzufügen gibt es
 \begin{center}
-\cppinline{einvektor.push_back(}\emph{Element}\cppinline{);}
+	\cppinline{einvektor.push_back(}\emph{Element}\cppinline{);}
 \end{center}
 und auf ein bestimmtes Vektorelement zugreifen könnt ihr indem ihr seinen Index in eckigen Klammern hinter den Namen schreibt.
 \begin{center}
-\cppinline{einvektor[}\emph{Index}\cppinline{]}
+	\cppinline{einvektor[}\emph{Index}\cppinline{]}
 \end{center}
 Wenn ihr die Größe eines Vektors wissen wollt könnt ihr
 \begin{center}
-\cppinline{einvektor.size()}
+	\cppinline{einvektor.size()}
 \end{center}
 verwenden.
 
@@ -35,31 +35,34 @@ Aus Versehen über den Vektor hinaus zu schreiben oder zu lesen ist ein so häuf
 Wichtig ist, dass der Compiler diesen Zugriff nicht verhindern wird!
 Das ist von daher eine sehr fiese Sache, als dass dieser Fehler auch beim Ausführen nicht immer Probleme machen wird -- aber manchmal lässt er auch euer Programm spontan abstürzen in einem so genannten \emph{segmentation fault}.
 
-\textbf{Praxis:}
-Wir wollen die Seite \url{http://www.ich-kann-mich-nicht-entscheiden.de/} nachmachen und eine Entscheidungshilfe programmieren, die aus mehreren von der Nutzerin gegebenen Möglichkeiten eine per Zufall auswählt.
+\begin{praxis}
 
-\begin{enumerate}
-	\item
-		Schreibt zunächst ein Programm, welches einen Vektor aus 10 Strings erstellt und die Nutzerin 10 mal nach einer Antwortmöglichkeit fragt und die gegebenen Antworten nacheinander in den Vektor schreibt.
-	\item
-		Fügt nun die Möglichkeit zu, weniger Antworten anzugeben.
-		Dazu könnt ihr zum Beispiel zuerst fragen, wie viele Antwortmöglichkeiten es geben soll und dann so oft fragen.
-	\item
-		Ihr könnt dann (so wie in dem Programm oben) eine Zufallszahl erzeugen.
-		Um sicher zu gehen, dass sie nicht zu groß wird, könnt ihr den Rest bei Teilung durch Anzahl der eingegebenen Antworten nehmen (sind z.B. 7 Antworten angegeben und die Zufallszahl ist 25778, so wäre der resultierende Index \texttt{25778 \% 7 == 4}).
-		Gebt dann die Antwortmöglichkeit aus, die dem zufallsgeneriertem Index entspricht.
-\end{enumerate}
+	Wir wollen die Seite \url{http://www.ich-kann-mich-nicht-entscheiden.de/} nachmachen und eine Entscheidungshilfe programmieren, die aus mehreren von der Nutzerin gegebenen Möglichkeiten eine per Zufall auswählt.
+
+	\begin{enumerate}
+		\item
+		      Schreibt zunächst ein Programm, welches einen Vektor aus 10 Strings erstellt und die Nutzerin 10 mal nach einer Antwortmöglichkeit fragt und die gegebenen Antworten nacheinander in den Vektor schreibt.
+		\item
+		      Fügt nun die Möglichkeit zu, weniger Antworten anzugeben.
+		      Dazu könnt ihr zum Beispiel zuerst fragen, wie viele Antwortmöglichkeiten es geben soll und dann so oft fragen.
+		\item
+		      Ihr könnt dann (so wie in dem Programm oben) eine Zufallszahl erzeugen.
+		      Um sicher zu gehen, dass sie nicht zu groß wird, könnt ihr den Rest bei Teilung durch Anzahl der eingegebenen Antworten nehmen (sind z.B. 7 Antworten angegeben und die Zufallszahl ist 25778, so wäre der resultierende Index \texttt{25778 \% 7 == 4}).
+		      Gebt dann die Antwortmöglichkeit aus, die dem zufallsgeneriertem Index entspricht.
+	\end{enumerate}
+\end{praxis}
 
 Sollte euer Programm einmal nicht korrekt kompilieren, denkt daran die Fehlermeldung sorgfältig zu lesen, damit sie euch Aufschluss über die Fehlerursache gibt.
 Sollte euer Programm zwar kompilieren, sich dann aber komisch verhalten, denkt daran, den debugger zu benutzen und es Schritt für Schritt durchzugehen, um die Fehlerquelle zu finden. Solltet ihr trotz alledem nicht weiter kommen, oder nicht wissen, was von euch erwartet wird, fragt einen
 von uns.
 
-\textbf{Spiel:}
-\begin{enumerate}
-	\item
-		Schreibt ein Progamm, welches einen Vektor mit einer beliebigen Anzahl an Elementen befüllt und dann auf einen Index weit über der tatsächlichen Größe schreibt.
-		Was beobachtet ihr?\footnote{Es wird natürlich Quark sein was dabei rauskommt, es geht hier haupsächlich darum das ihr seht was für einen Fehler das gibt}
-	\item
-		Implementiert das \emph{Sieb des Eratosthenes}\footnote{\url{https://de.wikipedia.org/wiki/Sieb_des_Eratosthenes}}, wenn ihr noch nicht ausgelastet seid.
-		Denkt daran, es initial zu befüllen und denkt euch eine clevere Möglichkeit aus, das „Streichen“ zu realisieren.
-\end{enumerate}
+\begin{spiel}
+	\begin{enumerate}
+		\item
+		      Schreibt ein Progamm, welches einen Vektor mit einer beliebigen Anzahl an Elementen befüllt und dann auf einen Index weit über der tatsächlichen Größe schreibt.
+		      Was beobachtet ihr?\footnote{Es wird natürlich Quark sein was dabei rauskommt, es geht hier haupsächlich darum das ihr seht was für einen Fehler das gibt}
+		\item
+		      Implementiert das \emph{Sieb des Eratosthenes}\footnote{\url{https://de.wikipedia.org/wiki/Sieb_des_Eratosthenes}}, wenn ihr noch nicht ausgelastet seid.
+		      Denkt daran, es initial zu befüllen und denkt euch eine clevere Möglichkeit aus, das „Streichen“ zu realisieren.
+	\end{enumerate}
+\end{spiel}

--- a/basics/warning.tex
+++ b/basics/warning.tex
@@ -9,86 +9,86 @@ anschauen, wie wir den Compiler in gewisser Weise „wachsam“ machen können,
 sodass er uns auch über Dinge informiert, die zwar keine Fehler sind, aber
 möglicherweise zu unerwartetem Verhalten führen können.
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Kompiliert \texttt{warnings.cpp}. Testet das Program mit
-        verschiedenen Eingaben. Was beobachtet ihr?
-\end{enumerate}
-\inputcpp{warnings.cpp}
+\begin{praxis}
+    \begin{enumerate}
+        \item Kompiliert \texttt{warnings.cpp}. Testet das Program mit
+              verschiedenen Eingaben. Was beobachtet ihr?
+    \end{enumerate}
+    \inputcpp{warnings.cpp}
 
-Fehler wie diese können nicht mehr auftreten, wenn ihr \emph{warnings}
-anschaltet. Dies passiert über weitere Optionen, die wir dem Compiler mitgeben.
+    Fehler wie diese können nicht mehr auftreten, wenn ihr \emph{warnings}
+    anschaltet. Dies passiert über weitere Optionen, die wir dem Compiler mitgeben.
 
-\textbf{Praxis:}
-\begin{enumerate}[resume]
-    \item Kompiliert \texttt{warnings.cpp} mittels \texttt{g++ -Wall -o
-        warnings warnings.cpp}.
-\end{enumerate}
+    \begin{enumerate}[resume]
+        \item Kompiliert \texttt{warnings.cpp} mittels \texttt{g++ -Wall -o
+                  warnings warnings.cpp}.
+    \end{enumerate}
 
-Warnings sehen im Wesentlichen genauso aus, wie Fehler. Der einzige Unterschied
-ist, dass statt \texttt{error} in der Zeile ein \texttt{warning} steht und dass
-der Compiler zwar die Meldung ausgibt, aber trotzdem ganz normal das Programm
-erzeugt. Trotzdem solltet ihr warnings ernst nehmen. Die meisten „ernsthaften“
-Programmierer aktivieren warnings, da die meisten davon gefundenen Meldungen
-tatsächlich behoben werden sollten.
+    Warnings sehen im Wesentlichen genauso aus, wie Fehler. Der einzige Unterschied
+    ist, dass statt \texttt{error} in der Zeile ein \texttt{warning} steht und dass
+    der Compiler zwar die Meldung ausgibt, aber trotzdem ganz normal das Programm
+    erzeugt. Trotzdem solltet ihr warnings ernst nehmen. Die meisten „ernsthaften“
+    Programmierer aktivieren warnings, da die meisten davon gefundenen Meldungen
+    tatsächlich behoben werden sollten.
 
-Ihr könnt mit verschiedenen Parametern beeinflussen, welche warnings euch der
-Compiler anzeigt und wie er damit umgeht. Wir wollen hier nur drei nennen:
+    Ihr könnt mit verschiedenen Parametern beeinflussen, welche warnings euch der
+    Compiler anzeigt und wie er damit umgeht. Wir wollen hier nur drei nennen:
 
-\begin{description}
-    \item[-Wall]
-        Aktiviert „alle“ warnings. Tatsächlich stimmt das so nicht, aber wenn
-        ihr immer daran denkt, diesen Parameter anzugeben, solltet ihr bereits
-        den allergrößten Teil der vom Compiler entdeckbaren Probleme, die ihr
-        erzeugt, abfangen können.
-    \item[-Wextra]
-        Aktiviert noch ein paar warnings (ihr seht, warum „alle“ in
-        Anführungszeichen stand). In einigen Fällen sind auch die hier
-        aktivierten warnings für euch relevant.
-    \item[-Werror]
-        Dieser Parameter führt dazu, dass jede warning als Fehler behandelt
-        wird, d.h. der Compiler bricht ab, wenn er eine warning produzieren
-        würde. Dieser Parameter ist hochumstritten und in der Praxis sollte man
-        ihn eigentlich nicht einsetzen. Für Beginner kann er aber hilfreich
-        sein, da er von vornherein antrainiert, warnings ernst zu nehmen und
-        sie nicht einfach zu ignorieren.
-\end{description}
+    \begin{description}
+        \item[-Wall]
+              Aktiviert „alle“ warnings. Tatsächlich stimmt das so nicht, aber wenn
+              ihr immer daran denkt, diesen Parameter anzugeben, solltet ihr bereits
+              den allergrößten Teil der vom Compiler entdeckbaren Probleme, die ihr
+              erzeugt, abfangen können.
+        \item[-Wextra]
+              Aktiviert noch ein paar warnings (ihr seht, warum „alle“ in
+              Anführungszeichen stand). In einigen Fällen sind auch die hier
+              aktivierten warnings für euch relevant.
+        \item[-Werror]
+              Dieser Parameter führt dazu, dass jede warning als Fehler behandelt
+              wird, d.h. der Compiler bricht ab, wenn er eine warning produzieren
+              würde. Dieser Parameter ist hochumstritten und in der Praxis sollte man
+              ihn eigentlich nicht einsetzen. Für Beginner kann er aber hilfreich
+              sein, da er von vornherein antrainiert, warnings ernst zu nehmen und
+              sie nicht einfach zu ignorieren.
+    \end{description}
 
-Wenn ihr bei jedem Compilerlauf nun warnings anschalten wollt -- und am Besten
-auch noch für den debugger, falls ihr ihn braucht -- wird der Befehl zum
-Kompilieren langsam sehr lang. Für die Dauer des Vorkurses könnt ihr euch
-mittels
+    Wenn ihr bei jedem Compilerlauf nun warnings anschalten wollt -- und am Besten
+    auch noch für den debugger, falls ihr ihn braucht -- wird der Befehl zum
+    Kompilieren langsam sehr lang. Für die Dauer des Vorkurses könnt ihr euch
+    mittels
 
-\begin{center}
-\texttt{alias\footnote{alias ist ein shell-befehl, der euch eine Reihe von
-Anweisungen und Befehlen neu benennen lässt. In diesem Fall ist danach zum
-Beispiel der noch nicht existente Befehl \texttt{compile} ein neuer Name für
-\texttt{g++ -Vall -Wextra -Werror -O0 -g3}. Beachtet, dass ihr hier genau das
-abtippen müsst, was da steht, mit Leerzeichen und allem} compile="g++ -Wall
--Wextra -Werror -O0 -g3"}
-\end{center}
+    \begin{center}
+        \texttt{alias\footnote{alias ist ein shell-befehl, der euch eine Reihe von
+                Anweisungen und Befehlen neu benennen lässt. In diesem Fall ist danach zum
+                Beispiel der noch nicht existente Befehl \texttt{compile} ein neuer Name für
+                \texttt{g++ -Vall -Wextra -Werror -O0 -g3}. Beachtet, dass ihr hier genau das
+                abtippen müsst, was da steht, mit Leerzeichen und allem} compile="g++ -Wall
+            -Wextra -Werror -O0 -g3"}
+    \end{center}
 
-ein bisschen Arbeit ersparen. Ein einfaches \texttt{compile -o foo foo.cpp}
-wird dann automatisch den Compiler mit allen angegebenen Optionen aufrufen. Den
-\texttt{alias} müsst ihr allerdings jedes mal, wenn ihr in der Zwischenzeit ein
-Terminal geschlossen habt, neu ausführen, denn er geht bei Schließung eines
-Terminals verloren!
+    ein bisschen Arbeit ersparen. Ein einfaches \texttt{compile -o foo foo.cpp}
+    wird dann automatisch den Compiler mit allen angegebenen Optionen aufrufen. Den
+    \texttt{alias} müsst ihr allerdings jedes mal, wenn ihr in der Zwischenzeit ein
+    Terminal geschlossen habt, neu ausführen, denn er geht bei Schließung eines
+    Terminals verloren!
 
-\textbf{Praxis:}
-\begin{enumerate}[resume]
-    \item Mit der warning in \texttt{warnings.cpp} möchte euch der Compiler
-        darauf hinweisen, dass ihr hier eine Zuweisung macht, obwohl ein
-        Wahrheitswert\footnote{Ein Wahrheitswert (\cppinline{bool}) ist ein
-        Variablentyp, der die Werte wahr (\cppinline{true}) und falsch (
-        \cppinline{false}) annehmen kann.}
-        erwartet wird. Es gibt zwei Möglichkeiten, die warning zu
-        beheben: Ihr könnt Klammern um die Zuweisung machen (und dem Compiler
-        so sagen, dass ihr euch sicher seid, dass hier eine Zuweisung hinsoll),
-        oder ihr könnt aus der Zuweisung einen Vergleich machen. Welche
-        Möglichkeit erscheint euch angebracht? Setzt sie um und kompiliert das
-        Programm erneut (mit warnings).
-    \item In \texttt{warnprim.cpp} haben wir einen Fehler eingebaut. Kompiliert
-        das Programm mit warnings und korrigiert ihn.
-\end{enumerate}
+    \begin{enumerate}[resume]
+        \item Mit der warning in \texttt{warnings.cpp} möchte euch der Compiler
+              darauf hinweisen, dass ihr hier eine Zuweisung macht, obwohl ein
+              Wahrheitswert\footnote{Ein Wahrheitswert (\cppinline{bool}) ist ein
+                  Variablentyp, der die Werte wahr (\cppinline{true}) und falsch (
+                  \cppinline{false}) annehmen kann.}
+              erwartet wird. Es gibt zwei Möglichkeiten, die warning zu
+              beheben: Ihr könnt Klammern um die Zuweisung machen (und dem Compiler
+              so sagen, dass ihr euch sicher seid, dass hier eine Zuweisung hinsoll),
+              oder ihr könnt aus der Zuweisung einen Vergleich machen. Welche
+              Möglichkeit erscheint euch angebracht? Setzt sie um und kompiliert das
+              Programm erneut (mit warnings).
+        \item In \texttt{warnprim.cpp} haben wir einen Fehler eingebaut. Kompiliert
+              das Programm mit warnings und korrigiert ihn.
+    \end{enumerate}
 
-\inputcpp{warnprim.cpp}
+    \inputcpp{warnprim.cpp}
+
+\end{praxis}

--- a/classes/enum.tex
+++ b/classes/enum.tex
@@ -16,8 +16,9 @@ Intern werden diese von 0 beginnend durchnummeriert, was jedoch für viele Zweck
 Mit einem '='-Zeichen hinter dem Zustand kann diesem explizit eine Zahl zugeweisen werden, die dieser repräsentiert.
 Dies kann in manchen Fällen sinnvoll sein, da Enums einfach in Integer verwandelt werden können (und anders herum).
 
-\textbf{Praxis:}
-\begin{enumerate}
-    \item Erweitere \texttt{runden2.cpp} so, dass auch negative Eingaben richtig gerundet werden. Bei Abrunden sollte die Eingabe -1.4 also auf 2 und bei Aufrunden auf 1 gerundet werden.
-    \item Füge zwei weitere modes hinzu, die jeweils zur Null und von der Null weg runden.
-\end{enumerate}
+\begin{praxis}
+    \begin{enumerate}
+        \item Erweitere \texttt{runden2.cpp} so, dass auch negative Eingaben richtig gerundet werden. Bei Abrunden sollte die Eingabe -1.4 also auf 2 und bei Aufrunden auf 1 gerundet werden.
+        \item Füge zwei weitere modes hinzu, die jeweils zur Null und von der Null weg runden.
+    \end{enumerate}
+\end{praxis}

--- a/classes/struct.tex
+++ b/classes/struct.tex
@@ -19,32 +19,35 @@ Das könnte zum Beispiel so aussehen:
 %
 %\includecpp{konst.cpp}
 
-\textbf{Praxis 1:}
-\begin{enumerate}
-    \item Schreibt einen neuen Struct, der ein Datum folgender Art repräsentiert: \texttt{"1 Januar 1971"}.
-        Dieser Struct sollte also drei Attribute haben:
-        ein \texttt{int}, um das Jahr zu speichern,
-        ein \texttt{std::string} für den Monat
-        und ein weiterer \texttt{int} für den Tag.
+\begin{praxis}
+    \begin{enumerate}
+        \item Schreibt einen neuen Struct, der ein Datum folgender Art repräsentiert: \texttt{"1 Januar 1971"}.
+              Dieser Struct sollte also drei Attribute haben:
+              ein \texttt{int}, um das Jahr zu speichern,
+              ein \texttt{std::string} für den Monat
+              und ein weiterer \texttt{int} für den Tag.
 
-    \item Erstellt eine Funktion, die einen \texttt{std::string} als Parameter entgegen nimmt, die Nutzerin mit der Ausgabe des Strings nach einem Datum fragt und dann das Datum mit eurem erstellten Struct zurück gibt.
+        \item Erstellt eine Funktion, die einen \texttt{std::string} als Parameter entgegen nimmt, die Nutzerin mit der Ausgabe des Strings nach einem Datum fragt und dann das Datum mit eurem erstellten Struct zurück gibt.
 
-    \item Fragt mit dieser Funktion die Benutzerin nach ihrem Geburtsdatum. Überprüft, ob ihr am gleichen Tag Geburtstag habt.
-Außerdem solltet ihr überprüfen, ob ihr im gleichen Jahr geboren seid.
-\end{enumerate}
+        \item Fragt mit dieser Funktion die Benutzerin nach ihrem Geburtsdatum. Überprüft, ob ihr am gleichen Tag Geburtstag habt.
+              Außerdem solltet ihr überprüfen, ob ihr im gleichen Jahr geboren seid.
+    \end{enumerate}
+\end{praxis}
+\begin{praxis}[(Quadratsfunktion)]
 
-\textbf{Praxis 2: (Quadratsfunktion)}
-\begin{enumerate}
-    \item Schreibt einen Struct \texttt{Point2D}, der zweidimensionale Punkte
-        repräsentieren soll. ($a = (x, y) \in \mathbb{R}^2$)
-    \item In einem früheren Kapitel habt ihr gelernt, wie man Arrays von
-        Datentypen anlegen kann. Erstellt ein Array aus 100 \texttt{Point2D}s, bei dem die
-        x-Werte von 0 bis 99 gehen.
-    \item Berechnet dann für jeden \texttt{x}-Wert das entsprechende \texttt{y},
-        indem ihr $y = x^2$ berechnet.
-\end{enumerate}
+    \begin{enumerate}
+        \item Schreibt einen Struct \texttt{Point2D}, der zweidimensionale Punkte
+              repräsentieren soll. ($a = (x, y) \in \mathbb{R}^2$)
+        \item In einem früheren Kapitel habt ihr gelernt, wie man Arrays von
+              Datentypen anlegen kann. Erstellt ein Array aus 100 \texttt{Point2D}s, bei dem die
+              x-Werte von 0 bis 99 gehen.
+        \item Berechnet dann für jeden \texttt{x}-Wert das entsprechende \texttt{y},
+              indem ihr $y = x^2$ berechnet.
+    \end{enumerate}
+\end{praxis}
 
-\textbf{Spiel:}
-\begin{enumerate}
-    \item ??
-\end{enumerate}
+\begin{spiel}
+    \begin{enumerate}
+        \item ??
+    \end{enumerate}
+\end{spiel}

--- a/vorkurs.cls
+++ b/vorkurs.cls
@@ -13,6 +13,7 @@
 \RequirePackage[ngerman]{babel}
 \RequirePackage{microtype}
 \RequirePackage{minted}
+\RequirePackage{needspace}
 
 %\setcounter{secnumdepth}{-1}
 \pagestyle{fancy}
@@ -37,6 +38,8 @@
 \newcommand{\lesson}[1]{\clearpage\vspace*{-42mm} \section{#1} \vspace*{30mm}\renewcommand{\myrightmark}{#1}}
 %\newcommand{\lesson}[1]{\section{#1}\vspace{5em}\markright{#1}}
 \renewcommand*\thesection{\arabic{section}}
+\newenvironment{praxis}[1][\unskip]{\Needspace{4\baselineskip}\textbf{Praxis: #1}}{\pagebreak[0]}
+\newenvironment{spiel}[1][\unskip]{\Needspace{4\baselineskip}\textbf{Spiel: #1}}{\pagebreak[0]}
 
 \titlecontents{chapter}[0pt]{\vspace{1em}\large}{\makebox[60pt][l]{\textbf{Kapitel \thecontentslabel:}}\hspace*{10pt}}{}{\titlerule*[1pc]{ }\contentspage}
 \titlecontents{section}[10pt]{}{\makebox[50pt][l]{Lektion \thecontentslabel:}\hspace*{10pt}}{}{\titlerule*[1pc]{ }\contentspage}


### PR DESCRIPTION
Es gibt jetzt eine `begin{praxis} ... \end{praxis}` und eine `begin{spiel} ... \end{spiel}` Umgebung. Innerhalb dieser Umgebung wird verhindert, dass in den ersten Zeilen direkt ein Seitenumbruch stattfindet. Allerdings passieren momentan noch doofe Seitenumbrüche am Ende der Umgebungen, meist im Code, das könnte man noch optimieren.