### PR TITLE
Einordnung des Debuggers und Referenzen in Schleifen und Kontrollfluss gefixt

### DIFF
--- a/basics/gdb.tex
+++ b/basics/gdb.tex
@@ -12,8 +12,8 @@ zum Beispiel ein vergessenes Semikolon, oder eine vergessene geschweifte
 Klammer), um fehlende header (wie die \verb|\#include <...>| heißen) oder um
 undefinierte Variablen.
 
-Eine andere, besonders fiese Klasse von Fehlern haben wir in der letzten
-Lektion kennengelernt. Wenn wir nämlich durch eine Variable teilen, und in
+Eine andere, besonders fiese Klasse von Fehlern haben wir in der Lektion des Kontrollflusses gelernt.
+Wenn wir nämlich durch eine Variable teilen, und in
 dieser Variable erst beim Programmlauf (zur \emph{Laufzeit}) eine 0 steht, so
 tritt eine so genannte \emph{floating point exception} auf. Der Compiler hat
 hier keine Chance, diesen Fehler zu erkennen - er weiß ja nicht, was der
@@ -24,18 +24,18 @@ es keine automatischen Tools gibt, die uns bei ihrer Suche helfen.
 
 \textbf{gdb}
 
-Wir werden (noch) nicht lernen, wie wir den Fehler aus der letzten Lektion
-beheben können, aber wir werden ein wichtiges Tool kennen lernen, um
-Laufzeitfehler aufzuspüren, damit wir wenigstens wissen, wo wir mit der Lösung
-anfangen können: Den \emph{GNU debugger}, oder kurz gdb.
+Wir haben zwar bereits bei einem so offensichtlichen Fehler bereits gelernt,
+wie wir diesen beheben können, dies ist allerdings nicht immer so einfach.
+Wir lernen nun ein wichtiges Tool kennen, um Laufzeitfehler auch bei komplexeren Programmen
+aufzuspüren, sodass wir wissen, wo wir mit der Lösung
+ansetzen müssen: Den \emph{GNU debugger}, oder kurz gdb.
 
 Der Debugger ist eine Möglichkeit, unser Programm in einer besonderen Umgebung
-laufen zu lassen, die es uns erlaubt es jederzeit anzuhalten, den Inhalt von
-Variablen zu untersuchen oder auch Anweisung für Anweisung unser Programm vom
-Computer durchgehen zu lassen.
+laufen zu lassen, die es uns erlaubt es jederzeit anzuhalten. So kann man den Inhalt von
+Variablen untersuchen oder auch Anweisung für Anweisung das Programm durchgehen.
 
-Damit er das tun kann, braucht er vom Compiler ein paar zusätzliche
-Informationen, über den Quellcode, die normalerweise verloren gehen. Wir müssen
+Damit wir das können, braucht der Compiler ein paar zusätzliche
+Informationen über den Quellcode, die normalerweise verloren gehen. Wir müssen
 dem Compiler dafür ein paar zusätzliche Optionen mitgeben:
 \begin{minted}{bash}
 g++ -O0 -g3 -o debugger debugger.cpp
@@ -76,7 +76,7 @@ g++ -O0 -g3 -o debugger debugger.cpp
 
 \begin{spiel}
 \begin{enumerate}
-        \item Im folgenden Programm \texttt{faculty.cpp} haben sich zwei Fehler eingeschlichen. Versucht diese mit \texttt{gdb} zu finden und zu beheben
+        \item Im folgenden Programm \texttt{faculty.cpp} haben sich zwei Fehler eingeschlichen. Versucht diese mit \texttt{gdb} zu finden und zu beheben.
         
         \inputcpp{faculty.cpp}
         

--- a/basics/kontrollfluss.tex
+++ b/basics/kontrollfluss.tex
@@ -1,23 +1,15 @@
 \lesson{Der Kontrollfluss}
 
-Nachdem wir ein bisschen etwas über den Debugger verstanden haben (wir werden
-ihn noch häufiger benutzen), können wir uns nun wieder unserem Problem mit der
-Division durch 0 zuwenden.
-
-\inputcpp{arith4.cpp}
-
-Wenn wir dieses Programm kompilieren und als zweite Zahl eine 0 eingeben,
-werden wir auf der Konsole ausgegeben bekommen:
+Wer versucht hat in der vergangenen Lektion Praxisaufgabe 5 zu lösen, wird auf der Konsole eine ähnliche Ausgabe wie folgt bekommen - einen Fehler:
 \begin{minted}{text}
 Gebe eine Zahl ein: 5
 Gebe noch eine Zahl ein: 0
 Floating point exception
 \end{minted}
-(Gegebenenfalls ist die letzte Zeile bei euch auch in einer anderen Sprache)
 
-Wir können das Programm auch einmal im debugger ausführen und werden wenig
-überraschend feststellen, dass die Anweisung, an der diese floating point
-exception auftritt die ist, in der die Division steht.
+Das Programmcode hierfür beispielsweise wie folgt aussehen.
+
+\inputcpp{arith4.cpp}
 
 Wenn wir diesen Fehler beheben wollen, haben wir eigentlich nur zwei
 Möglichkeiten: Die erste ist, die Schuld auf die Benutzerin zu schieben, warum
@@ -70,14 +62,11 @@ einfaches Gleichheitszeichen bedeutet Zuweisung („mache diese beiden gleich!�
 
 \begin{praxis}
       \begin{enumerate}
-            \item Kompiliert \texttt{if.cpp} für den debugger und lasst das Programm im
-                  gdb laufen. Geht Schritt für Schritt durch das Programm, mit
-                  verschiedenen Eingaben (wenn ihr am Ende des Programms angekommen seid,
-                  könnt ihr es mit einem erneuten „run“ neu starten)
             \item Nutzt Google, um herauszufinden, welche anderen Vergleichsoperatoren
                   es in \Cpp noch gibt. Versucht, das Programm so zu verändern, dass es
                   auf Ungleichheit testet, statt auf Gleichheit (sich sonst aber genauso
                   verhält).
+            
             \item Wie würdet ihr testen, ob zwei Zahlen durch einander teilbar sind
                   (Tipp: Ihr kennt bereits die Division mit Rest in \Cpp (modulo))?
                   Schreibt ein Programm, welches zwei Zahlen von der Nutzerin entgegen
@@ -89,8 +78,7 @@ einfaches Gleichheitszeichen bedeutet Zuweisung („mache diese beiden gleich!�
 \begin{enumerate}
     \item Testet mit verschiedenen Eingaben, was passiert, wenn ihr in
         \texttt{if.cpp} statt zwei Gleichheitszeichen nur eines benutzt.
-        Benutzt den debugger, um euch den Inhalt von \texttt{b} vor und nach
-        dem Test anzuschauen.
+
     \item Schreibt ein Programm, welches die Benutzerin fragt, wie sie heißt.
         Gibt sie euren eigenen Namen ein, soll das Programm begeistert über die
         Namensgleichheit sein, sonst sie einfach begrüßen.

--- a/basics/schleifen.tex
+++ b/basics/schleifen.tex
@@ -73,12 +73,10 @@ ihr könnt alleine mit den Mitteln, die ihr bisher kennen gelernt habt,
 
 \begin{praxis}
       \begin{enumerate}
-            \item Versucht, die Arbeitsweise eines debuggers zu simulieren. Geht selbst
-                  den Quellcode Zeile für Zeile durch, überlegt euch, was die Zeile tut
+            \item Versucht, die Arbeitsweise des Programms zu simulieren. Geht selbst
+                  den Quellcode Zeile für Zeile durch. Überlegt euch hierbei, was die Zeile tut
                   und welchen Inhalt die Variablen haben. Überlegt euch dann, wohin der
                   Computer (bei Kontrollflussstrukturen) als nächstes springen würde.
-                  Wenn ihr nicht weiter wisst, kompiliert das Programm für den debugger,
-                  startet es im debugger und geht es durch.
             \item Warum funktioniert das Programm für den Fall $n = 2$?
             \item Schreibt selbst ein Programm, welches eine Zahl von der Nutzerin
                   entgegennimmt und dann alle Zahlen bis zu dieser Zahl ausgibt.


### PR DESCRIPTION
Bitte angehängtes Vorkursskript Kapitel 7 - 11 auf Konsistenz überprüfen.

Bauen die Kapitel auf einander auf? 
Sind die Referenzen auf den Debugger bevor er in Kapitel 11 eingeführt wird auch tatsächlich verschwunden.

Falls ja, kann der commit angenommen werden.

[vorkurs.pdf](https://github.com/FachschaftMathPhysInfo/Programmiervorkurs/files/7239587/vorkurs.pdf)
